### PR TITLE
Fix ci update example

### DIFF
--- a/example/host_hid_to_device_cdc/CMakeLists.txt
+++ b/example/host_hid_to_device_cdc/CMakeLists.txt
@@ -13,6 +13,9 @@ target_sources(${target_name} PRIVATE
  ${PICO_PIO_USB_SRC}/pio_usb_device.c
  ${PICO_PIO_USB_SRC}/pio_usb_host.c
  ${PICO_PIO_USB_SRC}/usb_crc.c
+ # can use 'tinyusb_pico_pio_usb' library later when pico-sdk is updated
+ ${PICO_TINYUSB_PATH}/src/portable/raspberrypi/pio_usb/dcd_pio_usb.c
+ ${PICO_TINYUSB_PATH}/src/portable/raspberrypi/pio_usb/hcd_pio_usb.c
  )
 target_link_options(${target_name} PRIVATE -Xlinker --print-memory-usage)
 target_compile_options(${target_name} PRIVATE -Wall -Wextra)

--- a/example/host_hid_to_device_cdc/host_hid_to_device_cdc.c
+++ b/example/host_hid_to_device_cdc/host_hid_to_device_cdc.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Ha Thach (tinyusb.org)
@@ -70,8 +70,13 @@ static uint8_t const keycode2ascii[128][2] =  { HID_KEYCODE_TO_ASCII };
 void core1_main() {
   sleep_ms(10);
 
-  // To run USB SOF interrupt in core1, init host stack for pio_usb (roothub port1)
-  // on core1
+  // Use tuh_configure() to pass pio configuration to the host stack
+  // Note: tuh_configure() must be called before
+  pio_usb_configuration_t pio_cfg = PIO_USB_DEFAULT_CONFIG;
+  tuh_configure(1, TUH_CFGID_RPI_PIO_USB_CONFIGURATION, &pio_cfg);
+
+  // To run USB SOF interrupt in core1, init host stack for pio_usb (roothub
+  // port1) on core1
   tuh_init(1);
 
   while (true) {

--- a/example/host_hid_to_device_cdc/tusb_config.h
+++ b/example/host_hid_to_device_cdc/tusb_config.h
@@ -35,11 +35,13 @@
 //--------------------------------------------------------------------
 
 #define CFG_TUSB_OS               OPT_OS_PICO
-#define CFG_TUSB_RHPORT0_MODE     OPT_MODE_DEVICE
-#define CFG_TUSB_RHPORT1_MODE     OPT_MODE_HOST
 
-// Use raspberry pio-usb for host
-#define CFG_TUH_RPI_PIO_USB       1
+// Enable device stack
+#define CFG_TUD_ENABLED     1
+
+// Enable host stack with pio-usb if Pico-PIO-USB library is available
+#define CFG_TUH_ENABLED     1
+#define CFG_TUH_RPI_PIO_USB 1
 
 // CFG_TUSB_DEBUG is defined by compiler in DEBUG build
 // #define CFG_TUSB_DEBUG           0

--- a/src/pio_usb_host.c
+++ b/src/pio_usb_host.c
@@ -25,7 +25,7 @@ static bool timer_active;
 
 static volatile bool cancel_timer_flag;
 static volatile bool start_timer_flag;
-static uint32_t int_stat;
+static __unused uint32_t int_stat;
 
 static bool sof_timer(repeating_timer_t *_rt);
 
@@ -48,7 +48,7 @@ static void start_timer(alarm_pool_t *alarm_pool) {
   timer_active = true;
 }
 
-static void stop_timer(void) {
+static __unused void stop_timer(void) {
   cancel_repeating_timer(&sof_rt);
   timer_active = false;
 }


### PR DESCRIPTION
- update tinyusb host_hid_to_device_cdc example to fix ci build, also use new tuh_configure() to pass pio configuration
- fix unused warning with using with tinyusb