### PR TITLE
add weak alias attribute to built-in pio_usb_host_irq_handler / pio_usb_device_irq_handler 

### DIFF
--- a/example/host_hid_to_device_cdc/CMakeLists.txt
+++ b/example/host_hid_to_device_cdc/CMakeLists.txt
@@ -20,7 +20,6 @@ target_sources(${target_name} PRIVATE
 target_link_options(${target_name} PRIVATE -Xlinker --print-memory-usage)
 target_compile_options(${target_name} PRIVATE -Wall -Wextra)
 target_include_directories(${target_name} PRIVATE ${PICO_PIO_USB_SRC} ${CMAKE_CURRENT_LIST_DIR})
-target_compile_definitions(${target_name} PRIVATE PIO_USB_USE_TINYUSB)
 
 target_link_libraries(${target_name} PRIVATE pico_stdlib pico_multicore hardware_pio hardware_dma tinyusb_device tinyusb_host)
 pico_add_extra_outputs(${target_name})

--- a/src/pio_usb_device.c
+++ b/src/pio_usb_device.c
@@ -295,8 +295,6 @@ bool pio_usb_device_transfer(uint8_t ep_address, uint8_t *buffer,
 //--------------------------------------------------------------------+
 // USB Device Stack
 //--------------------------------------------------------------------+
-#ifndef PIO_USB_USE_TINYUSB
-
 static usb_descriptor_buffers_t descriptor_buffers;
 static int8_t ep0_desc_request_type = -1;
 static uint16_t ep0_desc_request_len;
@@ -427,7 +425,8 @@ static int __no_inline_not_in_flash_func(process_device_setup_stage)(uint8_t *bu
   return res;
 }
 
-void __no_inline_not_in_flash_func(pio_usb_device_irq_handler)(uint8_t root_idx) {
+// IRQ Handler
+static void __no_inline_not_in_flash_func(__pio_usb_device_irq_handler)(uint8_t root_idx) {
   root_port_t *root = PIO_USB_ROOT_PORT(root_idx);
   usb_device_t *dev = &pio_usb_device[0];
 
@@ -473,6 +472,7 @@ void __no_inline_not_in_flash_func(pio_usb_device_irq_handler)(uint8_t root_idx)
   root->ints &= ~ints;
 }
 
-#endif // PIO_USB_USE_TINYUSB
+// weak alias to __pio_usb_device_irq_handler
+void pio_usb_device_irq_handler(uint8_t root_id) __attribute__ ((weak, alias("__pio_usb_device_irq_handler")));
 
 #pragma GCC pop_options

--- a/src/pio_usb_host.c
+++ b/src/pio_usb_host.c
@@ -536,8 +536,6 @@ static int __no_inline_not_in_flash_func(usb_setup_transaction)(
 //--------------------------------------------------------------------+
 // USB Host Stack
 //--------------------------------------------------------------------+
-#ifndef PIO_USB_USE_TINYUSB
-
 static void on_device_connect(pio_port_t *pp, root_port_t *root,
                               int device_idx) {
   bool fullspeed_flag = false;
@@ -1255,7 +1253,7 @@ static void __no_inline_not_in_flash_func(handle_endpoint_irq)(
 }
 
 // IRQ Handler
-void __no_inline_not_in_flash_func(pio_usb_host_irq_handler)(uint8_t root_id) {
+static void __no_inline_not_in_flash_func(__pio_usb_host_irq_handler)(uint8_t root_id) {
   root_port_t *root = PIO_USB_ROOT_PORT(root_id);
   uint32_t const ints = root->ints;
 
@@ -1286,6 +1284,7 @@ void __no_inline_not_in_flash_func(pio_usb_host_irq_handler)(uint8_t root_id) {
   root->ints &= ~ints;
 }
 
-#endif // PIO_USB_USE_TINYUSB
+// weak alias to __pio_usb_host_irq_handler
+void pio_usb_host_irq_handler(uint8_t root_id) __attribute__ ((weak, alias("__pio_usb_host_irq_handler")));
 
 #pragma GCC pop_options

--- a/src/pio_usb_ll.h
+++ b/src/pio_usb_ll.h
@@ -152,7 +152,7 @@ pio_usb_ll_get_transaction_len(endpoint_t *ep) {
 //--------------------------------------------------------------------
 
 // Host IRQ Handler
-__attribute__((weak)) void pio_usb_host_irq_handler(uint8_t root_idx);
+void pio_usb_host_irq_handler(uint8_t root_idx);
 
 void pio_usb_host_port_reset_start(uint8_t root_idx);
 void pio_usb_host_port_reset_end(uint8_t root_idx);
@@ -172,7 +172,7 @@ bool pio_usb_host_endpoint_transfer(uint8_t root_idx, uint8_t device_address,
 //--------------------------------------------------------------------
 
 // Device IRQ Handler
-__attribute__((weak)) void pio_usb_device_irq_handler(uint8_t root_idx);
+void pio_usb_device_irq_handler(uint8_t root_idx);
 
 void pio_usb_device_set_address(uint8_t dev_addr);
 bool pio_usb_device_endpoint_open(uint8_t const *desc_endpoint);


### PR DESCRIPTION
- This is similar to startup file defining IRQHandler(). When linking with tinyusb which define `pio_usb_host_irq_handler/pio_usb_device_irq_handler` it will take tinyusb's implementation instead of the built-in one.
- For reference https://github.com/arduino/ArduinoCore-samd/blob/9f91accecc8298976670234e4d6ac0afef5c7a39/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/source/gcc/startup_samd21.c#L81
- This remove the need of defining PIO_USB_USE_TINYUSB when using with tinyusb. Sometimes as 3rd party library, we don't have the privilege to add compile option.

Pro: more portable, less macro to define
Cons: some of built-in stack won't be used, though compiler is more than capable to remove these symbol in final elf.    