### PR TITLE
Support swapped DP/DM pins

### DIFF
--- a/src/pio_usb_configuration.h
+++ b/src/pio_usb_configuration.h
@@ -1,21 +1,31 @@
 
 #pragma once
 
+typedef enum {
+  PIO_USB_PINOUT_DPDM = 0,  // DM = DP +1
+  PIO_USB_PINOUT_DMDP,      // DM = DP -1
+} PIO_USB_PINOUT;
+
 typedef struct {
-    uint8_t pin_dp;
-    uint8_t pio_tx_num;
-    uint8_t sm_tx;
-    uint8_t tx_ch;
-    uint8_t pio_rx_num;
-    uint8_t sm_rx;
-    uint8_t sm_eop;
-    void* alarm_pool;
-    int8_t debug_pin_rx;
-    int8_t debug_pin_eop;
+  uint8_t pin_dp;
+  PIO_USB_PINOUT pinout;
+  uint8_t pio_tx_num;
+  uint8_t sm_tx;
+  uint8_t tx_ch;
+  uint8_t pio_rx_num;
+  uint8_t sm_rx;
+  uint8_t sm_eop;
+  void* alarm_pool;
+  int8_t debug_pin_rx;
+  int8_t debug_pin_eop;
 } pio_usb_configuration_t;
 
 #ifndef PIO_USB_DP_PIN_DEFAULT
 #define PIO_USB_DP_PIN_DEFAULT 0
+#endif
+
+#ifndef PIO_USB_PINOUT_DEFAULT
+#define PIO_USB_PINOUT_DEFAULT PIO_USB_PINOUT_DPDM
 #endif
 
 #define PIO_USB_DM_PIN_DEFAULT (PIO_USB_DP_PIN_DEFAULT + 1)
@@ -30,12 +40,12 @@ typedef struct {
 
 #define PIO_USB_DEBUG_PIN_NONE (-1)
 
-#define PIO_USB_DEFAULT_CONFIG                                                 \
-  {                                                                            \
-    PIO_USB_DP_PIN_DEFAULT, PIO_USB_TX_DEFAULT, PIO_SM_USB_TX_DEFAULT,         \
-        PIO_USB_DMA_TX_DEFAULT, PIO_USB_RX_DEFAULT, PIO_SM_USB_RX_DEFAULT,     \
-        PIO_SM_USB_EOP_DEFAULT, NULL, PIO_USB_DEBUG_PIN_NONE,                  \
-        PIO_USB_DEBUG_PIN_NONE                                                 \
+#define PIO_USB_DEFAULT_CONFIG                                             \
+  {                                                                        \
+    PIO_USB_DP_PIN_DEFAULT, PIO_USB_PINOUT_DEFAULT, PIO_USB_TX_DEFAULT,    \
+        PIO_SM_USB_TX_DEFAULT, PIO_USB_DMA_TX_DEFAULT, PIO_USB_RX_DEFAULT, \
+        PIO_SM_USB_RX_DEFAULT, PIO_SM_USB_EOP_DEFAULT, NULL,               \
+        PIO_USB_DEBUG_PIN_NONE, PIO_USB_DEBUG_PIN_NONE                     \
   }
 
 #define PIO_USB_EP_POOL_CNT 32

--- a/src/pio_usb_host.c
+++ b/src/pio_usb_host.c
@@ -125,41 +125,41 @@ static __always_inline void override_pio_rx_program(PIO pio,
 
 static void __no_inline_not_in_flash_func(configure_fullspeed_host)(
     pio_port_t const *pp, root_port_t *port) {
-  override_pio_program(pp->pio_usb_tx, &usb_tx_fs_program, pp->offset_tx);
+  override_pio_program(pp->pio_usb_tx, pp->fs_tx_program, pp->offset_tx);
   SM_SET_CLKDIV(pp->pio_usb_tx, pp->sm_tx, pp->clk_div_fs_tx);
 
-  override_pio_rx_program(pp->pio_usb_rx, &usb_rx_fs_program,
-                          &usb_rx_fs_debug_program, pp->offset_rx,
+  override_pio_rx_program(pp->pio_usb_rx, &usb_rx_program,
+                          &usb_rx_debug_program, pp->offset_rx,
                           pp->debug_pin_rx);
   SM_SET_CLKDIV(pp->pio_usb_rx, pp->sm_rx, pp->clk_div_fs_rx);
 
-  override_pio_rx_program(pp->pio_usb_rx, &eop_detect_fs_program,
-                          &eop_detect_fs_debug_program, pp->offset_eop,
+  override_pio_rx_program(pp->pio_usb_rx, &eop_detect_pin0_program,
+                          &eop_detect_pin0_debug_program, pp->offset_eop,
                           pp->debug_pin_eop);
   SM_SET_CLKDIV(pp->pio_usb_rx, pp->sm_eop, pp->clk_div_fs_rx);
 
-  usb_tx_configure_pins(pp->pio_usb_tx, pp->sm_tx, port->pin_dp);
-  usb_rx_configure_pins(pp->pio_usb_rx, pp->sm_eop, port->pin_dp);
+  usb_tx_configure_pins(pp->pio_usb_tx, pp->sm_tx, port->pin_dp, port->pin_dm);
+  usb_eop_configure_pins(pp->pio_usb_rx, pp->sm_eop, port->pin_dp, port->pin_dm);
   usb_rx_configure_pins(pp->pio_usb_rx, pp->sm_rx, port->pin_dp);
 }
 
 static void __no_inline_not_in_flash_func(configure_lowspeed_host)(
     pio_port_t const *pp, root_port_t *port) {
-  override_pio_program(pp->pio_usb_tx, &usb_tx_ls_program, pp->offset_tx);
+  override_pio_program(pp->pio_usb_tx, pp->ls_tx_program, pp->offset_tx);
   SM_SET_CLKDIV(pp->pio_usb_tx, pp->sm_tx, pp->clk_div_ls_tx);
 
-  override_pio_rx_program(pp->pio_usb_rx, &usb_rx_ls_program,
-                          &usb_rx_ls_debug_program, pp->offset_rx,
+  override_pio_rx_program(pp->pio_usb_rx, &usb_rx_program,
+                          &usb_rx_debug_program, pp->offset_rx,
                           pp->debug_pin_rx);
   SM_SET_CLKDIV(pp->pio_usb_rx, pp->sm_rx, pp->clk_div_ls_rx);
 
-  override_pio_rx_program(pp->pio_usb_rx, &eop_detect_ls_program,
-                          &eop_detect_ls_debug_program, pp->offset_eop,
+  override_pio_rx_program(pp->pio_usb_rx, &eop_detect_pin1_program,
+                          &eop_detect_pin1_debug_program, pp->offset_eop,
                           pp->debug_pin_eop);
   SM_SET_CLKDIV(pp->pio_usb_rx, pp->sm_eop, pp->clk_div_ls_rx);
 
-  usb_tx_configure_pins(pp->pio_usb_tx, pp->sm_tx, port->pin_dp);
-  usb_rx_configure_pins(pp->pio_usb_rx, pp->sm_eop, port->pin_dp);
+  usb_tx_configure_pins(pp->pio_usb_tx, pp->sm_tx, port->pin_dp, port->pin_dm);
+  usb_eop_configure_pins(pp->pio_usb_rx, pp->sm_eop, port->pin_dp, port->pin_dm);
   usb_rx_configure_pins(pp->pio_usb_rx, pp->sm_rx, port->pin_dm);
 }
 

--- a/src/pio_usb_ll.h
+++ b/src/pio_usb_ll.h
@@ -63,6 +63,11 @@ typedef struct {
   int8_t debug_pin_rx;
   int8_t debug_pin_eop;
 
+  PIO_USB_PINOUT pinout;
+  const pio_program_t *fs_tx_program;
+  const pio_program_t *fs_tx_pre_program;
+  const pio_program_t *ls_tx_program;
+
   pio_clk_div_t clk_div_fs_tx;
   pio_clk_div_t clk_div_fs_rx;
   pio_clk_div_t clk_div_ls_tx;
@@ -98,8 +103,8 @@ extern pio_port_t pio_port[1];
 // Bus functions
 //--------------------------------------------------------------------+
 
-#define IRQ_TX_EOP_MASK (1 << usb_tx_fs_IRQ_EOP)
-#define IRQ_TX_COMP_MASK (1 << usb_tx_fs_IRQ_COMP)
+#define IRQ_TX_EOP_MASK (1 << usb_tx_dpdm_IRQ_EOP)
+#define IRQ_TX_COMP_MASK (1 << usb_tx_dpdm_IRQ_COMP)
 #define IRQ_TX_ALL_MASK (IRQ_TX_EOP_MASK | IRQ_TX_COMP_MASK)
 #define IRQ_RX_COMP_MASK (1 << IRQ_RX_EOP)
 #define IRQ_RX_ALL_MASK                                                        \

--- a/src/usb_rx.pio
+++ b/src/usb_rx.pio
@@ -1,7 +1,6 @@
 
 ; Copyright (c) 2021 sekigon-gonnoc
-; USB FS NRZI receiver
-; Run 48 MHz, autopull
+; USB FS/LS NRZI receiver
 
 .define public IRQ_RX_BS_ERR 1   ; bit stuffinc error
 .define public IRQ_RX_EOP    2   ; eop detect flag
@@ -13,14 +12,14 @@
 .define db0 0
 .define db1 1
 
-; USB FS receive program run at 96MHz
+; USB receive program
+; For Full-speed: run at 96MHz
+; For Low-speed: run at 12MHz
 ; shift to left, autopull enable
-; pin0: dp, pin1: dm
-; bit is captured from only dp. dm is used to detect eop
-.program usb_rx_fs
-
-.define J 0b01
-.define K 0b10
+; bit is captured from only pin0. pin1 is used to detect eop
+; For Full-speed: pin0 is dp
+; For Low-speed: pin0 is dm
+.program usb_rx
 
 .wrap_target
 start:
@@ -30,12 +29,12 @@ start:
 read2to1:
     set y, BR
 read1:
-    jmp PIN J1
-K1:
+    jmp PIN H1
+L1:
     set x, 0 [1]
     in x, 1  [1]
     jmp read1to2 [1]
-J1:
+H1:
     set x, 1 [2]
     in x, 1
     jmp y-- read1 [2]
@@ -44,13 +43,13 @@ J1:
 read1to2:
     set y, BR
 read2:
-    jmp PIN J2
-K2:
+    jmp PIN H2
+L2:
     set x, 1 [3]
     in x, 1  [1]
     jmp y-- read2
     jmp read2to1 [6]	; ignore bitstuff
-J2:
+H2:
     set x, 0 [3]
     in x, 1
     jmp read2to1
@@ -60,15 +59,15 @@ bs_err:
 .wrap
 
 
-; USB FS receive program run at 96MHz with debug pin
+; USB receive program with debug pin
+; For Full-speed: run at 96MHz
+; For Low-speed: run at 12MHz
 ; shift to left, autopull enable
-; pin0: dp, pin1: dm
-; bit is captured from only dp. dm is used to detect eop
-.program usb_rx_fs_debug
+; bit is captured from only pin0. pin1 is used to detect eop
+; For Full-speed: pin0 is dp
+; For Low-speed: pin0 is dm
+.program usb_rx_debug
 .side_set 1
-
-.define J 0b01
-.define K 0b10
 
 .wrap_target
 start:
@@ -78,12 +77,12 @@ start:
 read2to1:
     set y, BR   side db1
 read1:
-    jmp PIN J1	side db1
-K1:
+    jmp PIN H1	side db1
+L1:
     set x, 0 [1]	side db0
     in x, 1  [1]	side db1
     jmp read1to2 [1]	side db1
-J1:
+H1:
     set x, 1 [2]	side db0
     in x, 1     	side db1
     jmp y-- read1 [2]	side db1
@@ -92,13 +91,13 @@ J1:
 read1to2:
     set y, BR   side db1
 read2:
-    jmp PIN J2	side db1
-K2:
+    jmp PIN H2	side db1
+L2:
     set x, 1 [3]	side db0
     in x, 1  [1]    side db1
     jmp y-- read2 	side db1
     jmp read2to1 [6]	side db1            ; ignore bitstuff
-J2:
+H2:
     set x, 0 [3]	side db0
     in x, 1	side db1
     jmp read2to1   side db1
@@ -106,105 +105,14 @@ eop:
 bs_err:
     irq wait IRQ_RX_BS_ERR side db0
 .wrap
-
-; USB LS receive program run at 12MHz
-; shift to left, autopull enable
-; pin0: dm
-; bit is captured from only dm. dp is used to detect eop
-.program usb_rx_ls
-
-.define J 0b10
-.define K 0b01
-
-.wrap_target
-start:
-    wait 1 pin 0 [7]
-    wait 0 pin 0
-
-read2to1:
-    set y, BR
-read1:
-    jmp PIN J1
-K1:
-    set x, 0 [1]
-    in x, 1  [1]
-    jmp read1to2 [1]
-J1:
-    set x, 1 [2]
-    in x, 1
-    jmp y-- read1 [2]
-    jmp PIN bs_err [6]
-
-read1to2:
-    set y, BR
-read2:
-    jmp PIN J2
-K2:
-    set x, 1 [3]
-    in x, 1  [1]
-    jmp y-- read2
-    jmp read2to1 [6]	; ignore bitstuff
-J2:
-    set x, 0 [3]
-    in x, 1
-    jmp read2to1
-eop:
-bs_err:
-    irq wait IRQ_RX_BS_ERR
-.wrap
-
-; USB LS receive program run at 12MHz with debug pin
-; shift to left, autopull enable
-; pin0: dm
-; bit is captured from only dm. dp is used to detect eop
-.program usb_rx_ls_debug
-.side_set 1
-
-.define J 0b10
-.define K 0b01
-
-.wrap_target
-start:
-    wait 1 pin 0 [7]   side db0
-    wait 0 pin 0 	   side db0
-
-read2to1:
-    set y, BR   side db1
-read1:
-    jmp PIN J1	side db1
-K1:
-    set x, 0 [1]	side db0
-    in x, 1  [1]	side db1
-    jmp read1to2 [1]	side db1
-J1:
-    set x, 1 [2]	side db0
-    in x, 1     	side db1
-    jmp y-- read1 [2]	side db1
-    jmp PIN bs_err [6] side db1
-
-read1to2:
-    set y, BR   side db1
-read2:
-    jmp PIN J2	side db1
-K2:
-    set x, 1 [3]	side db0
-    in x, 1  [1]    side db1
-    jmp y-- read2 	side db1
-    jmp read2to1 [6]	side db1            ; ignore bitstuff
-J2:
-    set x, 0 [3]	side db0
-    in x, 1	side db1
-    jmp read2to1   side db1
-eop:
-bs_err:
-    irq wait IRQ_RX_BS_ERR side db0
-.wrap
-
 
 ; EOP detect program
-; run at 96MHz
+; For Full-speed: run at 96MHz
+; For Low-speed: run at 12MHz
 ; autopull disable
-.program eop_detect_fs
+; For Full-speed: pin0 is dp
+; For Low-speed: pin0 is dm
+.program eop_detect_pin0
 
 .wrap_target
     wait 1 pin 0        ; wait dp is H to avoid catch previous EOP
@@ -221,10 +129,9 @@ wait_se0:
     irq wait IRQ_RX_EOP ; eop is detected
 .wrap
 
-; EOP detect program with debug out
-; run at 96MHz
+; EOP detect program
 ; autopull disable
-.program eop_detect_fs_debug
+.program eop_detect_pin0_debug
 .side_set 1
 
 .wrap_target
@@ -243,9 +150,7 @@ wait_se0:
 .wrap
 
 ; EOP detect program
-; run at 12MHz
-; autopull disable
-.program eop_detect_ls
+.program eop_detect_pin1
 
 .wrap_target
     wait 1 pin 1        ; wait dm is H to avoid catch previous EOP
@@ -265,7 +170,7 @@ wait_se0:
 ; EOP detect program with debug out
 ; run at 12MHz
 ; autopull disable
-.program eop_detect_ls_debug
+.program eop_detect_pin1_debug
 .side_set 1
 
 .wrap_target
@@ -286,32 +191,35 @@ wait_se0:
 % c-sdk {
 #include "hardware/clocks.h"
 
-  static void __no_inline_not_in_flash_func(usb_rx_configure_pins)(PIO pio, uint sm, uint pin_dp) {
-    pio_sm_set_in_pins(pio, sm, pin_dp);
+static void __no_inline_not_in_flash_func(usb_rx_configure_pins)(PIO pio, uint sm, uint data_pin) {
+    pio_sm_set_in_pins(pio, sm, data_pin);
     pio->sm[sm].execctrl = (pio->sm[sm].execctrl & ~PIO_SM0_EXECCTRL_JMP_PIN_BITS) |
-                (pin_dp << PIO_SM0_EXECCTRL_JMP_PIN_LSB);
-  }
+                (data_pin << PIO_SM0_EXECCTRL_JMP_PIN_LSB);
+}
 
-static inline void usb_rx_fs_program_init(PIO pio, uint sm, uint offset, uint pin_dp, int pin_debug) {
-    pio_sm_set_consecutive_pindirs(pio, sm, pin_dp, 2, false);
+static void __no_inline_not_in_flash_func(usb_eop_configure_pins)(PIO pio, uint sm, uint pin_dp, uint pin_dm) {
+    uint pin0 = pin_dp < pin_dm ? pin_dp : pin_dm;
+    pio_sm_set_in_pins(pio, sm, pin0);
+}
+
+static inline void usb_rx_program_init(PIO pio, uint sm, uint offset, uint pin_dp, uint pin_dm, int pin_debug) {
+    pio_sm_set_pindirs_with_mask(pio, sm, 0, (1 << pin_dp));
+    pio_sm_set_pindirs_with_mask(pio, sm, 0, (1 << pin_dm));
     gpio_pull_down(pin_dp);
-    gpio_pull_down(pin_dp + 1);  // dm
+    gpio_pull_down(pin_dm);
 
     pio_sm_config c;
 
     if (pin_debug < 0) {
-      c = usb_rx_fs_program_get_default_config(offset);
+      c = usb_rx_program_get_default_config(offset);
     } else {
-      c = usb_rx_fs_debug_program_get_default_config(offset);
+      c = usb_rx_debug_program_get_default_config(offset);
 
       pio_sm_set_pins_with_mask(pio, sm, 0, 1 << pin_debug);
       pio_sm_set_pindirs_with_mask(pio, sm, 1 << pin_debug, 1 << pin_debug);
       pio_gpio_init(pio, pin_debug);
       sm_config_set_sideset_pins(&c, pin_debug);
     }
-
-    sm_config_set_in_pins(&c, pin_dp);  // for WAIT, IN
-    sm_config_set_jmp_pin(&c, pin_dp);  // for JMP
 
     // Shift to right, autopull enabled, 8bit
     sm_config_set_in_shift(&c, true, true, 8);
@@ -326,56 +234,21 @@ static inline void usb_rx_fs_program_init(PIO pio, uint sm, uint offset, uint pi
     pio_sm_set_enabled(pio, sm, false);
 }
 
-static inline void usb_rx_ls_program_init(PIO pio, uint sm, uint offset, uint pin_dp, int pin_debug) {
-    pio_sm_set_consecutive_pindirs(pio, sm, pin_dp, 2, false);
-    gpio_pull_down(pin_dp);
-    gpio_pull_down(pin_dp + 1);  // dm
-
-    pio_sm_config c;
-
-    if (pin_debug < 0) {
-      c = usb_rx_ls_program_get_default_config(offset);
-    } else {
-      c = usb_rx_ls_debug_program_get_default_config(offset);
-
-      pio_sm_set_pins_with_mask(pio, sm, 0, 1 << pin_debug);
-      pio_sm_set_pindirs_with_mask(pio, sm, 1 << pin_debug, 1 << pin_debug);
-      pio_gpio_init(pio, pin_debug);
-      sm_config_set_sideset_pins(&c, pin_debug);
-    }
-
-    sm_config_set_in_pins(&c, pin_dp + 1);  // for WAIT, IN
-    sm_config_set_jmp_pin(&c, pin_dp + 1);  // for JMP
-
-    // Shift to right, autopull enabled, 8bit
-    sm_config_set_in_shift(&c, true, true, 8);
-    sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_RX);
-
-    // Run at 12Mhz
-    // system clock should be multiple of 12MHz
-    float div = (float)clock_get_hz(clk_sys) / (12000000);
-    sm_config_set_clkdiv(&c, div);
-
-    pio_sm_init(pio, sm, offset, &c);
-    pio_sm_set_enabled(pio, sm, false);
-}
-
-static inline void eop_detect_fs_program_init(PIO pio, uint sm, uint offset,
-                                           uint pin_dp, bool is_fs, int pin_debug) {
+static inline void eop_detect_program_init(PIO pio, uint sm, uint offset,
+                                           uint pin_dp, uint pin_dm, bool is_fs, int pin_debug) {
   pio_sm_config c;
 
   if (pin_debug < 0) {
-    c = eop_detect_fs_program_get_default_config(offset);
+    c = eop_detect_pin0_program_get_default_config(offset);
   } else {
-    c = eop_detect_fs_debug_program_get_default_config(offset);
+    c = eop_detect_pin0_debug_program_get_default_config(offset);
     pio_sm_set_pins_with_mask(pio, sm, 0, 1 << pin_debug);
     pio_sm_set_pindirs_with_mask(pio, sm, 1 << pin_debug, 1 << pin_debug);
     pio_gpio_init(pio, pin_debug);
     sm_config_set_sideset_pins(&c, pin_debug);
   }
 
-  sm_config_set_in_pins(&c, pin_dp);  // for WAIT, IN
-  sm_config_set_jmp_pin(&c, pin_dp);  // for JMP
+  usb_eop_configure_pins(pio, sm, pin_dp, pin_dm);
 
   sm_config_set_in_shift(&c, false, false, 8);
 
@@ -385,30 +258,6 @@ static inline void eop_detect_fs_program_init(PIO pio, uint sm, uint offset,
   } else {
     div = (float)clock_get_hz(clk_sys) / (12000000);
   }
-
-  sm_config_set_clkdiv(&c, div);
-
-  pio_sm_init(pio, sm, offset, &c);
-  pio_sm_set_enabled(pio, sm, true);
-}
-
-static inline void eop_detect_ls_program_init(PIO pio, uint sm, uint offset,
-                                           uint pin_dp, int pin_debug) {
-  pio_sm_config c;
-
-  if (pin_debug < 0) {
-    c = eop_detect_ls_program_get_default_config(offset);
-  } else {
-    c = eop_detect_ls_debug_program_get_default_config(offset);
-  }
-
-  sm_config_set_in_pins(&c, pin_dp);  // for WAIT, IN
-  sm_config_set_jmp_pin(&c, pin_dp);  // for JMP
-
-  sm_config_set_in_shift(&c, false, false, 8);
-
-  float div;
-  div = (float)clock_get_hz(clk_sys) / (12000000);
 
   sm_config_set_clkdiv(&c, div);
 

--- a/src/usb_rx.pio.h
+++ b/src/usb_rx.pio.h
@@ -12,14 +12,14 @@
 #define IRQ_RX_EOP 2
 #define IRQ_RX_START 3
 
-// --------- //
-// usb_rx_fs //
-// --------- //
+// ------ //
+// usb_rx //
+// ------ //
 
-#define usb_rx_fs_wrap_target 0
-#define usb_rx_fs_wrap 20
+#define usb_rx_wrap_target 0
+#define usb_rx_wrap 20
 
-static const uint16_t usb_rx_fs_program_instructions[] = {
+static const uint16_t usb_rx_program_instructions[] = {
             //     .wrap_target
     0x27a0, //  0: wait   1 pin, 0               [7] 
     0x2020, //  1: wait   0 pin, 0                   
@@ -46,27 +46,27 @@ static const uint16_t usb_rx_fs_program_instructions[] = {
 };
 
 #if !PICO_NO_HARDWARE
-static const struct pio_program usb_rx_fs_program = {
-    .instructions = usb_rx_fs_program_instructions,
+static const struct pio_program usb_rx_program = {
+    .instructions = usb_rx_program_instructions,
     .length = 21,
     .origin = -1,
 };
 
-static inline pio_sm_config usb_rx_fs_program_get_default_config(uint offset) {
+static inline pio_sm_config usb_rx_program_get_default_config(uint offset) {
     pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + usb_rx_fs_wrap_target, offset + usb_rx_fs_wrap);
+    sm_config_set_wrap(&c, offset + usb_rx_wrap_target, offset + usb_rx_wrap);
     return c;
 }
 #endif
 
-// --------------- //
-// usb_rx_fs_debug //
-// --------------- //
+// ------------ //
+// usb_rx_debug //
+// ------------ //
 
-#define usb_rx_fs_debug_wrap_target 0
-#define usb_rx_fs_debug_wrap 20
+#define usb_rx_debug_wrap_target 0
+#define usb_rx_debug_wrap 20
 
-static const uint16_t usb_rx_fs_debug_program_instructions[] = {
+static const uint16_t usb_rx_debug_program_instructions[] = {
             //     .wrap_target
     0x27a0, //  0: wait   1 pin, 0        side 0 [7] 
     0x3020, //  1: wait   0 pin, 0        side 1     
@@ -93,123 +93,28 @@ static const uint16_t usb_rx_fs_debug_program_instructions[] = {
 };
 
 #if !PICO_NO_HARDWARE
-static const struct pio_program usb_rx_fs_debug_program = {
-    .instructions = usb_rx_fs_debug_program_instructions,
+static const struct pio_program usb_rx_debug_program = {
+    .instructions = usb_rx_debug_program_instructions,
     .length = 21,
     .origin = -1,
 };
 
-static inline pio_sm_config usb_rx_fs_debug_program_get_default_config(uint offset) {
+static inline pio_sm_config usb_rx_debug_program_get_default_config(uint offset) {
     pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + usb_rx_fs_debug_wrap_target, offset + usb_rx_fs_debug_wrap);
+    sm_config_set_wrap(&c, offset + usb_rx_debug_wrap_target, offset + usb_rx_debug_wrap);
     sm_config_set_sideset(&c, 1, false, false);
     return c;
 }
 #endif
 
-// --------- //
-// usb_rx_ls //
-// --------- //
-
-#define usb_rx_ls_wrap_target 0
-#define usb_rx_ls_wrap 20
-
-static const uint16_t usb_rx_ls_program_instructions[] = {
-            //     .wrap_target
-    0x27a0, //  0: wait   1 pin, 0               [7] 
-    0x2020, //  1: wait   0 pin, 0                   
-    0xe045, //  2: set    y, 5                       
-    0x00c7, //  3: jmp    pin, 7                     
-    0xe120, //  4: set    x, 0                   [1] 
-    0x4121, //  5: in     x, 1                   [1] 
-    0x010b, //  6: jmp    11                     [1] 
-    0xe221, //  7: set    x, 1                   [2] 
-    0x4021, //  8: in     x, 1                       
-    0x0283, //  9: jmp    y--, 3                 [2] 
-    0x06d4, // 10: jmp    pin, 20                [6] 
-    0xe045, // 11: set    y, 5                       
-    0x00d1, // 12: jmp    pin, 17                    
-    0xe321, // 13: set    x, 1                   [3] 
-    0x4121, // 14: in     x, 1                   [1] 
-    0x008c, // 15: jmp    y--, 12                    
-    0x0602, // 16: jmp    2                      [6] 
-    0xe320, // 17: set    x, 0                   [3] 
-    0x4021, // 18: in     x, 1                       
-    0x0002, // 19: jmp    2                          
-    0xc021, // 20: irq    wait 1                     
-            //     .wrap
-};
-
-#if !PICO_NO_HARDWARE
-static const struct pio_program usb_rx_ls_program = {
-    .instructions = usb_rx_ls_program_instructions,
-    .length = 21,
-    .origin = -1,
-};
-
-static inline pio_sm_config usb_rx_ls_program_get_default_config(uint offset) {
-    pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + usb_rx_ls_wrap_target, offset + usb_rx_ls_wrap);
-    return c;
-}
-#endif
-
 // --------------- //
-// usb_rx_ls_debug //
+// eop_detect_pin0 //
 // --------------- //
 
-#define usb_rx_ls_debug_wrap_target 0
-#define usb_rx_ls_debug_wrap 20
+#define eop_detect_pin0_wrap_target 0
+#define eop_detect_pin0_wrap 9
 
-static const uint16_t usb_rx_ls_debug_program_instructions[] = {
-            //     .wrap_target
-    0x27a0, //  0: wait   1 pin, 0        side 0 [7] 
-    0x2020, //  1: wait   0 pin, 0        side 0     
-    0xf045, //  2: set    y, 5            side 1     
-    0x10c7, //  3: jmp    pin, 7          side 1     
-    0xe120, //  4: set    x, 0            side 0 [1] 
-    0x5121, //  5: in     x, 1            side 1 [1] 
-    0x110b, //  6: jmp    11              side 1 [1] 
-    0xe221, //  7: set    x, 1            side 0 [2] 
-    0x5021, //  8: in     x, 1            side 1     
-    0x1283, //  9: jmp    y--, 3          side 1 [2] 
-    0x16d4, // 10: jmp    pin, 20         side 1 [6] 
-    0xf045, // 11: set    y, 5            side 1     
-    0x10d1, // 12: jmp    pin, 17         side 1     
-    0xe321, // 13: set    x, 1            side 0 [3] 
-    0x5121, // 14: in     x, 1            side 1 [1] 
-    0x108c, // 15: jmp    y--, 12         side 1     
-    0x1602, // 16: jmp    2               side 1 [6] 
-    0xe320, // 17: set    x, 0            side 0 [3] 
-    0x5021, // 18: in     x, 1            side 1     
-    0x1002, // 19: jmp    2               side 1     
-    0xc021, // 20: irq    wait 1          side 0     
-            //     .wrap
-};
-
-#if !PICO_NO_HARDWARE
-static const struct pio_program usb_rx_ls_debug_program = {
-    .instructions = usb_rx_ls_debug_program_instructions,
-    .length = 21,
-    .origin = -1,
-};
-
-static inline pio_sm_config usb_rx_ls_debug_program_get_default_config(uint offset) {
-    pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + usb_rx_ls_debug_wrap_target, offset + usb_rx_ls_debug_wrap);
-    sm_config_set_sideset(&c, 1, false, false);
-    return c;
-}
-#endif
-
-// ------------- //
-// eop_detect_fs //
-// ------------- //
-
-#define eop_detect_fs_wrap_target 0
-#define eop_detect_fs_wrap 9
-
-static const uint16_t eop_detect_fs_program_instructions[] = {
+static const uint16_t eop_detect_pin0_program_instructions[] = {
             //     .wrap_target
     0x20a0, //  0: wait   1 pin, 0                   
     0x2020, //  1: wait   0 pin, 0                   
@@ -225,27 +130,27 @@ static const uint16_t eop_detect_fs_program_instructions[] = {
 };
 
 #if !PICO_NO_HARDWARE
-static const struct pio_program eop_detect_fs_program = {
-    .instructions = eop_detect_fs_program_instructions,
+static const struct pio_program eop_detect_pin0_program = {
+    .instructions = eop_detect_pin0_program_instructions,
     .length = 10,
     .origin = -1,
 };
 
-static inline pio_sm_config eop_detect_fs_program_get_default_config(uint offset) {
+static inline pio_sm_config eop_detect_pin0_program_get_default_config(uint offset) {
     pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + eop_detect_fs_wrap_target, offset + eop_detect_fs_wrap);
+    sm_config_set_wrap(&c, offset + eop_detect_pin0_wrap_target, offset + eop_detect_pin0_wrap);
     return c;
 }
 #endif
 
-// ------------------- //
-// eop_detect_fs_debug //
-// ------------------- //
+// --------------------- //
+// eop_detect_pin0_debug //
+// --------------------- //
 
-#define eop_detect_fs_debug_wrap_target 0
-#define eop_detect_fs_debug_wrap 9
+#define eop_detect_pin0_debug_wrap_target 0
+#define eop_detect_pin0_debug_wrap 9
 
-static const uint16_t eop_detect_fs_debug_program_instructions[] = {
+static const uint16_t eop_detect_pin0_debug_program_instructions[] = {
             //     .wrap_target
     0x30a0, //  0: wait   1 pin, 0        side 1     
     0x3020, //  1: wait   0 pin, 0        side 1     
@@ -261,28 +166,28 @@ static const uint16_t eop_detect_fs_debug_program_instructions[] = {
 };
 
 #if !PICO_NO_HARDWARE
-static const struct pio_program eop_detect_fs_debug_program = {
-    .instructions = eop_detect_fs_debug_program_instructions,
+static const struct pio_program eop_detect_pin0_debug_program = {
+    .instructions = eop_detect_pin0_debug_program_instructions,
     .length = 10,
     .origin = -1,
 };
 
-static inline pio_sm_config eop_detect_fs_debug_program_get_default_config(uint offset) {
+static inline pio_sm_config eop_detect_pin0_debug_program_get_default_config(uint offset) {
     pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + eop_detect_fs_debug_wrap_target, offset + eop_detect_fs_debug_wrap);
+    sm_config_set_wrap(&c, offset + eop_detect_pin0_debug_wrap_target, offset + eop_detect_pin0_debug_wrap);
     sm_config_set_sideset(&c, 1, false, false);
     return c;
 }
 #endif
 
-// ------------- //
-// eop_detect_ls //
-// ------------- //
+// --------------- //
+// eop_detect_pin1 //
+// --------------- //
 
-#define eop_detect_ls_wrap_target 0
-#define eop_detect_ls_wrap 9
+#define eop_detect_pin1_wrap_target 0
+#define eop_detect_pin1_wrap 9
 
-static const uint16_t eop_detect_ls_program_instructions[] = {
+static const uint16_t eop_detect_pin1_program_instructions[] = {
             //     .wrap_target
     0x20a1, //  0: wait   1 pin, 1                   
     0x2021, //  1: wait   0 pin, 1                   
@@ -298,27 +203,27 @@ static const uint16_t eop_detect_ls_program_instructions[] = {
 };
 
 #if !PICO_NO_HARDWARE
-static const struct pio_program eop_detect_ls_program = {
-    .instructions = eop_detect_ls_program_instructions,
+static const struct pio_program eop_detect_pin1_program = {
+    .instructions = eop_detect_pin1_program_instructions,
     .length = 10,
     .origin = -1,
 };
 
-static inline pio_sm_config eop_detect_ls_program_get_default_config(uint offset) {
+static inline pio_sm_config eop_detect_pin1_program_get_default_config(uint offset) {
     pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + eop_detect_ls_wrap_target, offset + eop_detect_ls_wrap);
+    sm_config_set_wrap(&c, offset + eop_detect_pin1_wrap_target, offset + eop_detect_pin1_wrap);
     return c;
 }
 #endif
 
-// ------------------- //
-// eop_detect_ls_debug //
-// ------------------- //
+// --------------------- //
+// eop_detect_pin1_debug //
+// --------------------- //
 
-#define eop_detect_ls_debug_wrap_target 0
-#define eop_detect_ls_debug_wrap 9
+#define eop_detect_pin1_debug_wrap_target 0
+#define eop_detect_pin1_debug_wrap 9
 
-static const uint16_t eop_detect_ls_debug_program_instructions[] = {
+static const uint16_t eop_detect_pin1_debug_program_instructions[] = {
             //     .wrap_target
     0x30a1, //  0: wait   1 pin, 1        side 1     
     0x3021, //  1: wait   0 pin, 1        side 1     
@@ -334,41 +239,44 @@ static const uint16_t eop_detect_ls_debug_program_instructions[] = {
 };
 
 #if !PICO_NO_HARDWARE
-static const struct pio_program eop_detect_ls_debug_program = {
-    .instructions = eop_detect_ls_debug_program_instructions,
+static const struct pio_program eop_detect_pin1_debug_program = {
+    .instructions = eop_detect_pin1_debug_program_instructions,
     .length = 10,
     .origin = -1,
 };
 
-static inline pio_sm_config eop_detect_ls_debug_program_get_default_config(uint offset) {
+static inline pio_sm_config eop_detect_pin1_debug_program_get_default_config(uint offset) {
     pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + eop_detect_ls_debug_wrap_target, offset + eop_detect_ls_debug_wrap);
+    sm_config_set_wrap(&c, offset + eop_detect_pin1_debug_wrap_target, offset + eop_detect_pin1_debug_wrap);
     sm_config_set_sideset(&c, 1, false, false);
     return c;
 }
 
 #include "hardware/clocks.h"
-  static void __no_inline_not_in_flash_func(usb_rx_configure_pins)(PIO pio, uint sm, uint pin_dp) {
-    pio_sm_set_in_pins(pio, sm, pin_dp);
+static void __no_inline_not_in_flash_func(usb_rx_configure_pins)(PIO pio, uint sm, uint data_pin) {
+    pio_sm_set_in_pins(pio, sm, data_pin);
     pio->sm[sm].execctrl = (pio->sm[sm].execctrl & ~PIO_SM0_EXECCTRL_JMP_PIN_BITS) |
-                (pin_dp << PIO_SM0_EXECCTRL_JMP_PIN_LSB);
-  }
-static inline void usb_rx_fs_program_init(PIO pio, uint sm, uint offset, uint pin_dp, int pin_debug) {
-    pio_sm_set_consecutive_pindirs(pio, sm, pin_dp, 2, false);
+                (data_pin << PIO_SM0_EXECCTRL_JMP_PIN_LSB);
+}
+static void __no_inline_not_in_flash_func(usb_eop_configure_pins)(PIO pio, uint sm, uint pin_dp, uint pin_dm) {
+    uint pin0 = pin_dp < pin_dm ? pin_dp : pin_dm;
+    pio_sm_set_in_pins(pio, sm, pin0);
+}
+static inline void usb_rx_program_init(PIO pio, uint sm, uint offset, uint pin_dp, uint pin_dm, int pin_debug) {
+    pio_sm_set_pindirs_with_mask(pio, sm, 0, (1 << pin_dp));
+    pio_sm_set_pindirs_with_mask(pio, sm, 0, (1 << pin_dm));
     gpio_pull_down(pin_dp);
-    gpio_pull_down(pin_dp + 1);  // dm
+    gpio_pull_down(pin_dm);
     pio_sm_config c;
     if (pin_debug < 0) {
-      c = usb_rx_fs_program_get_default_config(offset);
+      c = usb_rx_program_get_default_config(offset);
     } else {
-      c = usb_rx_fs_debug_program_get_default_config(offset);
+      c = usb_rx_debug_program_get_default_config(offset);
       pio_sm_set_pins_with_mask(pio, sm, 0, 1 << pin_debug);
       pio_sm_set_pindirs_with_mask(pio, sm, 1 << pin_debug, 1 << pin_debug);
       pio_gpio_init(pio, pin_debug);
       sm_config_set_sideset_pins(&c, pin_debug);
     }
-    sm_config_set_in_pins(&c, pin_dp);  // for WAIT, IN
-    sm_config_set_jmp_pin(&c, pin_dp);  // for JMP
     // Shift to right, autopull enabled, 8bit
     sm_config_set_in_shift(&c, true, true, 8);
     sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_RX);
@@ -379,46 +287,19 @@ static inline void usb_rx_fs_program_init(PIO pio, uint sm, uint offset, uint pi
     pio_sm_init(pio, sm, offset, &c);
     pio_sm_set_enabled(pio, sm, false);
 }
-static inline void usb_rx_ls_program_init(PIO pio, uint sm, uint offset, uint pin_dp, int pin_debug) {
-    pio_sm_set_consecutive_pindirs(pio, sm, pin_dp, 2, false);
-    gpio_pull_down(pin_dp);
-    gpio_pull_down(pin_dp + 1);  // dm
-    pio_sm_config c;
-    if (pin_debug < 0) {
-      c = usb_rx_ls_program_get_default_config(offset);
-    } else {
-      c = usb_rx_ls_debug_program_get_default_config(offset);
-      pio_sm_set_pins_with_mask(pio, sm, 0, 1 << pin_debug);
-      pio_sm_set_pindirs_with_mask(pio, sm, 1 << pin_debug, 1 << pin_debug);
-      pio_gpio_init(pio, pin_debug);
-      sm_config_set_sideset_pins(&c, pin_debug);
-    }
-    sm_config_set_in_pins(&c, pin_dp + 1);  // for WAIT, IN
-    sm_config_set_jmp_pin(&c, pin_dp + 1);  // for JMP
-    // Shift to right, autopull enabled, 8bit
-    sm_config_set_in_shift(&c, true, true, 8);
-    sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_RX);
-    // Run at 12Mhz
-    // system clock should be multiple of 12MHz
-    float div = (float)clock_get_hz(clk_sys) / (12000000);
-    sm_config_set_clkdiv(&c, div);
-    pio_sm_init(pio, sm, offset, &c);
-    pio_sm_set_enabled(pio, sm, false);
-}
-static inline void eop_detect_fs_program_init(PIO pio, uint sm, uint offset,
-                                           uint pin_dp, bool is_fs, int pin_debug) {
+static inline void eop_detect_program_init(PIO pio, uint sm, uint offset,
+                                           uint pin_dp, uint pin_dm, bool is_fs, int pin_debug) {
   pio_sm_config c;
   if (pin_debug < 0) {
-    c = eop_detect_fs_program_get_default_config(offset);
+    c = eop_detect_pin0_program_get_default_config(offset);
   } else {
-    c = eop_detect_fs_debug_program_get_default_config(offset);
+    c = eop_detect_pin0_debug_program_get_default_config(offset);
     pio_sm_set_pins_with_mask(pio, sm, 0, 1 << pin_debug);
     pio_sm_set_pindirs_with_mask(pio, sm, 1 << pin_debug, 1 << pin_debug);
     pio_gpio_init(pio, pin_debug);
     sm_config_set_sideset_pins(&c, pin_debug);
   }
-  sm_config_set_in_pins(&c, pin_dp);  // for WAIT, IN
-  sm_config_set_jmp_pin(&c, pin_dp);  // for JMP
+  usb_eop_configure_pins(pio, sm, pin_dp, pin_dm);
   sm_config_set_in_shift(&c, false, false, 8);
   float div;
   if (is_fs) {
@@ -426,23 +307,6 @@ static inline void eop_detect_fs_program_init(PIO pio, uint sm, uint offset,
   } else {
     div = (float)clock_get_hz(clk_sys) / (12000000);
   }
-  sm_config_set_clkdiv(&c, div);
-  pio_sm_init(pio, sm, offset, &c);
-  pio_sm_set_enabled(pio, sm, true);
-}
-static inline void eop_detect_ls_program_init(PIO pio, uint sm, uint offset,
-                                           uint pin_dp, int pin_debug) {
-  pio_sm_config c;
-  if (pin_debug < 0) {
-    c = eop_detect_ls_program_get_default_config(offset);
-  } else {
-    c = eop_detect_ls_debug_program_get_default_config(offset);
-  }
-  sm_config_set_in_pins(&c, pin_dp);  // for WAIT, IN
-  sm_config_set_jmp_pin(&c, pin_dp);  // for JMP
-  sm_config_set_in_shift(&c, false, false, 8);
-  float div;
-  div = (float)clock_get_hz(clk_sys) / (12000000);
   sm_config_set_clkdiv(&c, div);
   pio_sm_init(pio, sm, offset, &c);
   pio_sm_set_enabled(pio, sm, true);

--- a/src/usb_tx.pio
+++ b/src/usb_tx.pio
@@ -3,20 +3,24 @@
 .define public USB_TX_EOP_OFFSET 4
 .define public USB_TX_EOP_DISABLER_LEN 4
 
-; USB FS NRZI transmitter
-; Run 48 MHz, autopull
-.program usb_tx_fs
+; USB NRZI transmitter
+; Run at 48 MHz for full-spped
+; Run at 6 MHz for low-spped
+; autopull enabled
+.program usb_tx_dpdm
 .side_set 2 opt
 
-.define J 0b01
-.define K 0b10
+; J for fs, K for ls
+.define FJ_LK 0b01
+; K for fs, J for ls
+.define FK_LJ 0b10
 .define SE0 0b00
 .define BR 5         ; bit repeat limit
 .define public IRQ_COMP 0   ; complete flag bit
 .define public IRQ_EOP 1   ; EOP start flag bit
 
 start:
-    set y, BR side J
+    set y, BR side FJ_LK
     set pindirs, 0b11
 
 .wrap_target
@@ -26,7 +30,7 @@ check_eop1:
 send_eop:
     irq IRQ_EOP side SE0 [3]    ; To catch quik ACK, mark as complete here
     nop [3]
-    nop side J
+    nop side FJ_LK
     set pindirs, 0b00 [3]
     irq wait IRQ_COMP
     jmp start
@@ -34,10 +38,10 @@ load_bit1:
     out x, 1
     jmp !x low1
 high1:
-    jmp y-- check_eop1 side J
+    jmp y-- check_eop1 side FJ_LK
     nop [2]                     ; bit stuffing
 low1:
-    set y BR side K
+    set y BR side FK_LJ
 
 check_eop2:
     jmp !osre load_bit2
@@ -46,15 +50,16 @@ load_bit2:
     out x, 1
     jmp !x low2
 high2:
-    jmp y-- check_eop2 side K
+    jmp y-- check_eop2 side FK_LJ
     nop [2]                     ; bit stuffing
 low2:
-    set y BR side J
+    set y BR side FJ_LK
 .wrap
 
-; USB FS transmitter for PRE packet (No EOP)
-; Run 48 MHz, autopull
-.program usb_tx_fs_pre
+; USB transmitter for PRE packet (No EOP)
+; Run at 48 MHz for full-spped
+; autopull enabled
+.program usb_tx_pre_dpdm
 .side_set 2 opt
 
 .define J 0b01
@@ -102,9 +107,61 @@ low2:
 .wrap
 
 
-; USB LS Transmitter
-; Run 6MHz, autopull
-.program usb_tx_ls
+; USB NRZI transmitter
+; Run at 48 MHz for full-spped
+; Run at 6 MHz for low-spped
+; autopull enabled
+.program usb_tx_dmdp
+.side_set 2 opt
+
+.define FK_LJ 0b10
+.define FJ_LK 0b01
+.define SE0 0b00
+.define BR 5         ; bit repeat limit
+.define public IRQ_COMP 0   ; complete flag bit
+.define public IRQ_EOP 1   ; EOP start flag bit
+
+start:
+    set y, BR side FK_LJ
+    set pindirs, 0b11
+
+.wrap_target
+check_eop1:
+    jmp !osre load_bit1
+    nop [1]
+send_eop:
+    irq IRQ_EOP side SE0 [3]
+    nop [3]
+    nop side FK_LJ
+    set pindirs, 0b00 [3]
+    irq wait IRQ_COMP
+    jmp start
+load_bit1:
+    out x, 1
+    jmp !x low1
+high1:
+    jmp y-- check_eop1 side FK_LJ
+    nop [2]                     ; bit stuffing
+low1:
+    set y BR side FJ_LK
+
+check_eop2:
+    jmp !osre load_bit2
+    jmp send_eop [1]
+load_bit2:
+    out x, 1
+    jmp !x low2
+high2:
+    jmp y-- check_eop2 side FJ_LK
+    nop [2]                     ; bit stuffing
+low2:
+    set y BR side FK_LJ
+.wrap
+
+; USB transmitter for PRE packet (No EOP)
+; Run at 48 MHz for full-spped
+; autopull enabled
+.program usb_tx_pre_dmdp
 .side_set 2 opt
 
 .define J 0b10
@@ -123,10 +180,10 @@ check_eop1:
     jmp !osre load_bit1
     nop [1]
 send_eop:
-    irq IRQ_EOP side SE0 [3]
-    nop [3]
-    nop side J
-    set pindirs, 0b00 [3]
+    irq IRQ_EOP side J [3]
+    set pindirs, 0b00
+    nop ; to align program size
+    nop ; to align program size
     irq wait IRQ_COMP
     jmp start
 load_bit1:
@@ -152,26 +209,31 @@ low2:
 .wrap
 
 
-
 % c-sdk {
 #include "hardware/clocks.h"
 
-  static void __no_inline_not_in_flash_func(usb_tx_configure_pins)(PIO pio, uint sm, uint pin_dp) {
-    pio_sm_set_out_pins(pio, sm, pin_dp, 2);
-    pio_sm_set_set_pins(pio, sm, pin_dp, 2);
-    pio_sm_set_sideset_pins(pio, sm, pin_dp);
+  static void __no_inline_not_in_flash_func(usb_tx_configure_pins)(PIO pio, uint sm, uint pin_dp, uint pin_dm) {
+    if (pin_dp < pin_dm) {
+      pio_sm_set_out_pins(pio, sm, pin_dp, 2);
+      pio_sm_set_set_pins(pio, sm, pin_dp, 2);
+      pio_sm_set_sideset_pins(pio, sm, pin_dp);
+    } else {
+      pio_sm_set_out_pins(pio, sm, pin_dm, 2);
+      pio_sm_set_set_pins(pio, sm, pin_dm, 2);
+      pio_sm_set_sideset_pins(pio, sm, pin_dm);
+    }
   }
 
   static inline void usb_tx_fs_program_init(PIO pio, uint sm, uint offset,
-                                         uint pin_dp) {
-    pio_sm_set_pins_with_mask(pio, sm, (0b01 << pin_dp), (0b11 << pin_dp));
+                                         uint pin_dp, uint pin_dm) {
+    pio_sm_set_pins_with_mask(pio, sm, (1 << pin_dp), ((1 << pin_dp) | (1 << pin_dm)));
 
     gpio_pull_down(pin_dp);
-    gpio_pull_down(pin_dp + 1); // dm
+    gpio_pull_down(pin_dm);
     pio_gpio_init(pio, pin_dp);
-    pio_gpio_init(pio, pin_dp + 1); // dm
+    pio_gpio_init(pio, pin_dm);
 
-    pio_sm_config c = usb_tx_fs_program_get_default_config(offset);
+    pio_sm_config c = usb_tx_dpdm_program_get_default_config(offset);
 
     // shifts to left, autopull, 8bit
     sm_config_set_out_shift(&c, true, true, 8);
@@ -184,20 +246,20 @@ low2:
     sm_config_set_clkdiv(&c, div);
 
     pio_sm_init(pio, sm, offset, &c);
-    usb_tx_configure_pins(pio, sm, pin_dp);
+    usb_tx_configure_pins(pio, sm, pin_dp, pin_dm);
     pio_sm_set_enabled(pio, sm, true);
   }
 
   static inline void usb_tx_ls_program_init(PIO pio, uint sm, uint offset,
-                                         uint pin_dp) {
-    pio_sm_set_pins_with_mask(pio, sm, (0b10 << pin_dp), (0b11 << pin_dp));
+                                         uint pin_dp, uint pin_dm) {
+    pio_sm_set_pins_with_mask(pio, sm, (1 << pin_dm), ((1 << pin_dp) | (1 << pin_dm)));
 
     gpio_pull_down(pin_dp);
-    gpio_pull_down(pin_dp + 1); // dm
+    gpio_pull_down(pin_dm);
     pio_gpio_init(pio, pin_dp);
-    pio_gpio_init(pio, pin_dp + 1); // dm
+    pio_gpio_init(pio, pin_dm);
 
-    pio_sm_config c = usb_tx_ls_program_get_default_config(offset);
+    pio_sm_config c = usb_tx_dmdp_program_get_default_config(offset);
 
     // shifts to left, autopull, 8bit
     sm_config_set_out_shift(&c, true, true, 8);
@@ -210,7 +272,7 @@ low2:
     sm_config_set_clkdiv(&c, div);
 
     pio_sm_init(pio, sm, offset, &c);
-    usb_tx_configure_pins(pio, sm, pin_dp);
+    usb_tx_configure_pins(pio, sm, pin_dp, pin_dm);
     pio_sm_set_enabled(pio, sm, true);
   }
 

--- a/src/usb_tx.pio.h
+++ b/src/usb_tx.pio.h
@@ -11,17 +11,17 @@
 #define USB_TX_EOP_OFFSET 4
 #define USB_TX_EOP_DISABLER_LEN 4
 
-// --------- //
-// usb_tx_fs //
-// --------- //
+// ----------- //
+// usb_tx_dpdm //
+// ----------- //
 
-#define usb_tx_fs_wrap_target 2
-#define usb_tx_fs_wrap 21
+#define usb_tx_dpdm_wrap_target 2
+#define usb_tx_dpdm_wrap 21
 
-#define usb_tx_fs_IRQ_COMP 0
-#define usb_tx_fs_IRQ_EOP 1
+#define usb_tx_dpdm_IRQ_COMP 0
+#define usb_tx_dpdm_IRQ_EOP 1
 
-static const uint16_t usb_tx_fs_program_instructions[] = {
+static const uint16_t usb_tx_dpdm_program_instructions[] = {
     0xf445, //  0: set    y, 5            side 1     
     0xe083, //  1: set    pindirs, 3                 
             //     .wrap_target
@@ -49,31 +49,31 @@ static const uint16_t usb_tx_fs_program_instructions[] = {
 };
 
 #if !PICO_NO_HARDWARE
-static const struct pio_program usb_tx_fs_program = {
-    .instructions = usb_tx_fs_program_instructions,
+static const struct pio_program usb_tx_dpdm_program = {
+    .instructions = usb_tx_dpdm_program_instructions,
     .length = 22,
     .origin = -1,
 };
 
-static inline pio_sm_config usb_tx_fs_program_get_default_config(uint offset) {
+static inline pio_sm_config usb_tx_dpdm_program_get_default_config(uint offset) {
     pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + usb_tx_fs_wrap_target, offset + usb_tx_fs_wrap);
+    sm_config_set_wrap(&c, offset + usb_tx_dpdm_wrap_target, offset + usb_tx_dpdm_wrap);
     sm_config_set_sideset(&c, 3, true, false);
     return c;
 }
 #endif
 
-// ------------- //
-// usb_tx_fs_pre //
-// ------------- //
+// --------------- //
+// usb_tx_pre_dpdm //
+// --------------- //
 
-#define usb_tx_fs_pre_wrap_target 2
-#define usb_tx_fs_pre_wrap 21
+#define usb_tx_pre_dpdm_wrap_target 2
+#define usb_tx_pre_dpdm_wrap 21
 
-#define usb_tx_fs_pre_IRQ_COMP 0
-#define usb_tx_fs_pre_IRQ_EOP 1
+#define usb_tx_pre_dpdm_IRQ_COMP 0
+#define usb_tx_pre_dpdm_IRQ_EOP 1
 
-static const uint16_t usb_tx_fs_pre_program_instructions[] = {
+static const uint16_t usb_tx_pre_dpdm_program_instructions[] = {
     0xf445, //  0: set    y, 5            side 1     
     0xe083, //  1: set    pindirs, 3                 
             //     .wrap_target
@@ -101,31 +101,31 @@ static const uint16_t usb_tx_fs_pre_program_instructions[] = {
 };
 
 #if !PICO_NO_HARDWARE
-static const struct pio_program usb_tx_fs_pre_program = {
-    .instructions = usb_tx_fs_pre_program_instructions,
+static const struct pio_program usb_tx_pre_dpdm_program = {
+    .instructions = usb_tx_pre_dpdm_program_instructions,
     .length = 22,
     .origin = -1,
 };
 
-static inline pio_sm_config usb_tx_fs_pre_program_get_default_config(uint offset) {
+static inline pio_sm_config usb_tx_pre_dpdm_program_get_default_config(uint offset) {
     pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + usb_tx_fs_pre_wrap_target, offset + usb_tx_fs_pre_wrap);
+    sm_config_set_wrap(&c, offset + usb_tx_pre_dpdm_wrap_target, offset + usb_tx_pre_dpdm_wrap);
     sm_config_set_sideset(&c, 3, true, false);
     return c;
 }
 #endif
 
-// --------- //
-// usb_tx_ls //
-// --------- //
+// ----------- //
+// usb_tx_dmdp //
+// ----------- //
 
-#define usb_tx_ls_wrap_target 2
-#define usb_tx_ls_wrap 21
+#define usb_tx_dmdp_wrap_target 2
+#define usb_tx_dmdp_wrap 21
 
-#define usb_tx_ls_IRQ_COMP 0
-#define usb_tx_ls_IRQ_EOP 1
+#define usb_tx_dmdp_IRQ_COMP 0
+#define usb_tx_dmdp_IRQ_EOP 1
 
-static const uint16_t usb_tx_ls_program_instructions[] = {
+static const uint16_t usb_tx_dmdp_program_instructions[] = {
     0xf845, //  0: set    y, 5            side 2     
     0xe083, //  1: set    pindirs, 3                 
             //     .wrap_target
@@ -153,33 +153,91 @@ static const uint16_t usb_tx_ls_program_instructions[] = {
 };
 
 #if !PICO_NO_HARDWARE
-static const struct pio_program usb_tx_ls_program = {
-    .instructions = usb_tx_ls_program_instructions,
+static const struct pio_program usb_tx_dmdp_program = {
+    .instructions = usb_tx_dmdp_program_instructions,
     .length = 22,
     .origin = -1,
 };
 
-static inline pio_sm_config usb_tx_ls_program_get_default_config(uint offset) {
+static inline pio_sm_config usb_tx_dmdp_program_get_default_config(uint offset) {
     pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + usb_tx_ls_wrap_target, offset + usb_tx_ls_wrap);
+    sm_config_set_wrap(&c, offset + usb_tx_dmdp_wrap_target, offset + usb_tx_dmdp_wrap);
+    sm_config_set_sideset(&c, 3, true, false);
+    return c;
+}
+#endif
+
+// --------------- //
+// usb_tx_pre_dmdp //
+// --------------- //
+
+#define usb_tx_pre_dmdp_wrap_target 2
+#define usb_tx_pre_dmdp_wrap 21
+
+#define usb_tx_pre_dmdp_IRQ_COMP 0
+#define usb_tx_pre_dmdp_IRQ_EOP 1
+
+static const uint16_t usb_tx_pre_dmdp_program_instructions[] = {
+    0xf845, //  0: set    y, 5            side 2     
+    0xe083, //  1: set    pindirs, 3                 
+            //     .wrap_target
+    0x00ea, //  2: jmp    !osre, 10                  
+    0xa142, //  3: nop                           [1] 
+    0xdb01, //  4: irq    nowait 1        side 2 [3] 
+    0xe080, //  5: set    pindirs, 0                 
+    0xa042, //  6: nop                               
+    0xa042, //  7: nop                               
+    0xc020, //  8: irq    wait 0                     
+    0x0000, //  9: jmp    0                          
+    0x6021, // 10: out    x, 1                       
+    0x002e, // 11: jmp    !x, 14                     
+    0x1882, // 12: jmp    y--, 2          side 2     
+    0xa242, // 13: nop                           [2] 
+    0xf445, // 14: set    y, 5            side 1     
+    0x00f1, // 15: jmp    !osre, 17                  
+    0x0104, // 16: jmp    4                      [1] 
+    0x6021, // 17: out    x, 1                       
+    0x0035, // 18: jmp    !x, 21                     
+    0x148f, // 19: jmp    y--, 15         side 1     
+    0xa242, // 20: nop                           [2] 
+    0xf845, // 21: set    y, 5            side 2     
+            //     .wrap
+};
+
+#if !PICO_NO_HARDWARE
+static const struct pio_program usb_tx_pre_dmdp_program = {
+    .instructions = usb_tx_pre_dmdp_program_instructions,
+    .length = 22,
+    .origin = -1,
+};
+
+static inline pio_sm_config usb_tx_pre_dmdp_program_get_default_config(uint offset) {
+    pio_sm_config c = pio_get_default_sm_config();
+    sm_config_set_wrap(&c, offset + usb_tx_pre_dmdp_wrap_target, offset + usb_tx_pre_dmdp_wrap);
     sm_config_set_sideset(&c, 3, true, false);
     return c;
 }
 
 #include "hardware/clocks.h"
-  static void __no_inline_not_in_flash_func(usb_tx_configure_pins)(PIO pio, uint sm, uint pin_dp) {
-    pio_sm_set_out_pins(pio, sm, pin_dp, 2);
-    pio_sm_set_set_pins(pio, sm, pin_dp, 2);
-    pio_sm_set_sideset_pins(pio, sm, pin_dp);
+  static void __no_inline_not_in_flash_func(usb_tx_configure_pins)(PIO pio, uint sm, uint pin_dp, uint pin_dm) {
+    if (pin_dp < pin_dm) {
+      pio_sm_set_out_pins(pio, sm, pin_dp, 2);
+      pio_sm_set_set_pins(pio, sm, pin_dp, 2);
+      pio_sm_set_sideset_pins(pio, sm, pin_dp);
+    } else {
+      pio_sm_set_out_pins(pio, sm, pin_dm, 2);
+      pio_sm_set_set_pins(pio, sm, pin_dm, 2);
+      pio_sm_set_sideset_pins(pio, sm, pin_dm);
+    }
   }
   static inline void usb_tx_fs_program_init(PIO pio, uint sm, uint offset,
-                                         uint pin_dp) {
-    pio_sm_set_pins_with_mask(pio, sm, (0b01 << pin_dp), (0b11 << pin_dp));
+                                         uint pin_dp, uint pin_dm) {
+    pio_sm_set_pins_with_mask(pio, sm, (1 << pin_dp), ((1 << pin_dp) | (1 << pin_dm)));
     gpio_pull_down(pin_dp);
-    gpio_pull_down(pin_dp + 1); // dm
+    gpio_pull_down(pin_dm);
     pio_gpio_init(pio, pin_dp);
-    pio_gpio_init(pio, pin_dp + 1); // dm
-    pio_sm_config c = usb_tx_fs_program_get_default_config(offset);
+    pio_gpio_init(pio, pin_dm);
+    pio_sm_config c = usb_tx_dpdm_program_get_default_config(offset);
     // shifts to left, autopull, 8bit
     sm_config_set_out_shift(&c, true, true, 8);
     sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_TX);
@@ -188,17 +246,17 @@ static inline pio_sm_config usb_tx_ls_program_get_default_config(uint offset) {
     float div = (float)clock_get_hz(clk_sys) / (48000000UL);
     sm_config_set_clkdiv(&c, div);
     pio_sm_init(pio, sm, offset, &c);
-    usb_tx_configure_pins(pio, sm, pin_dp);
+    usb_tx_configure_pins(pio, sm, pin_dp, pin_dm);
     pio_sm_set_enabled(pio, sm, true);
   }
   static inline void usb_tx_ls_program_init(PIO pio, uint sm, uint offset,
-                                         uint pin_dp) {
-    pio_sm_set_pins_with_mask(pio, sm, (0b10 << pin_dp), (0b11 << pin_dp));
+                                         uint pin_dp, uint pin_dm) {
+    pio_sm_set_pins_with_mask(pio, sm, (1 << pin_dm), ((1 << pin_dp) | (1 << pin_dm)));
     gpio_pull_down(pin_dp);
-    gpio_pull_down(pin_dp + 1); // dm
+    gpio_pull_down(pin_dm);
     pio_gpio_init(pio, pin_dp);
-    pio_gpio_init(pio, pin_dp + 1); // dm
-    pio_sm_config c = usb_tx_ls_program_get_default_config(offset);
+    pio_gpio_init(pio, pin_dm);
+    pio_sm_config c = usb_tx_dmdp_program_get_default_config(offset);
     // shifts to left, autopull, 8bit
     sm_config_set_out_shift(&c, true, true, 8);
     sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_TX);
@@ -207,7 +265,7 @@ static inline pio_sm_config usb_tx_ls_program_get_default_config(uint offset) {
     float div = (float)clock_get_hz(clk_sys) / (6000000UL);
     sm_config_set_clkdiv(&c, div);
     pio_sm_init(pio, sm, offset, &c);
-    usb_tx_configure_pins(pio, sm, pin_dp);
+    usb_tx_configure_pins(pio, sm, pin_dp, pin_dm);
     pio_sm_set_enabled(pio, sm, true);
   }
 


### PR DESCRIPTION
implement #29

* Add new configuration option `pinout`
  * For example,
    *  pin_dp=1, pinout=PIO_USB_PINOUT_DPDM (default) > pin_dp=1, pin_dm = 2
    *  pin_dp=1, pinout=PIO_USB_PINOUT_DMDP (default) > pin_dp=1, pin_dm = 0
  * To set pinout, define `PIO_USB_PINOUT_DEFAULT` as `PIO_USB_PINOUT_DPDM`(default)/`PIO_USB_PINOUT_DMDP`, or set pio_usb_configuration.pinout` 