### PR TITLE
Update the first packet in the Data Stage of a Control Transfer to use Data1, per USB specification. 

### DIFF
--- a/src/pio_usb_host.c
+++ b/src/pio_usb_host.c
@@ -512,7 +512,7 @@ static int __no_inline_not_in_flash_func(usb_setup_transaction)(
   }
 
   // Data
-  ep->data_id = 0; // set to DATA0
+  ep->data_id = 1; // set to DATA1
   pio_usb_bus_usb_transfer(pp, ep->buffer, 12);
 
   // Handshake


### PR DESCRIPTION
This should resolve [https://github.com/sekigon-gonnoc/Pico-PIO-USB/issues/55](url). 