### PR TITLE
fix control data & status stage always start with DATA1

### DIFF
--- a/src/pio_usb_host.c
+++ b/src/pio_usb_host.c
@@ -408,11 +408,12 @@ bool pio_usb_host_endpoint_transfer(uint8_t root_idx, uint8_t device_address,
     return false;
   }
 
-  // control endpoint switch direction when switch stage
-  if (ep->ep_num != ep_address) {
+  // Control endpoint, address may switch between 0x00 <-> 0x80
+  // therefore we need to update ep_num and is_tx
+  if ((ep_address & 0x7f) == 0) {
     ep->ep_num = ep_address;
-    ep->data_id = 1; // data and status always start with DATA1
     ep->is_tx = (ep_address == 0) ? true : false;
+    ep->data_id = 1; // data and status always start with DATA1
   }
 
   return pio_usb_ll_transfer_start(ep, buffer, buflen);


### PR DESCRIPTION
control data & status stage always start with DATA1. This pr fixes an issue with an Control OUT transfer (with data) where the PID is incorrectly DATA0. This should fix #55 

PS: This issue is kind of critical for me to get host cdc running (need SET LINE CODING). @sekigon-gonnoc if possible, would you mind making a release after reviewed/merged. Thank you in advance.