### PR TITLE
add pio_usb_host_get_frame_number()

### DIFF
--- a/src/pio_usb.h
+++ b/src/pio_usb.h
@@ -14,7 +14,7 @@ int pio_usb_host_add_port(uint8_t pin_dp);
 void pio_usb_host_task(void);
 void pio_usb_host_stop(void);
 void pio_usb_host_restart(void);
-uint16_t pio_usb_host_get_frame_number(void);
+uint32_t pio_usb_host_get_frame_number(void);
 
 // Device functions
 usb_device_t *pio_usb_device_init(const pio_usb_configuration_t *c,

--- a/src/pio_usb.h
+++ b/src/pio_usb.h
@@ -14,6 +14,7 @@ int pio_usb_host_add_port(uint8_t pin_dp);
 void pio_usb_host_task(void);
 void pio_usb_host_stop(void);
 void pio_usb_host_restart(void);
+uint16_t pio_usb_host_get_frame_number(void);
 
 // Device functions
 usb_device_t *pio_usb_device_init(const pio_usb_configuration_t *c,

--- a/src/pio_usb_host.c
+++ b/src/pio_usb_host.c
@@ -21,7 +21,7 @@
 
 static alarm_pool_t *_alarm_pool = NULL;
 static repeating_timer_t sof_rt;
-static uint16_t sof_count = 0;
+static uint32_t sof_count = 0;
 static bool timer_active;
 
 static volatile bool cancel_timer_flag;
@@ -288,10 +288,12 @@ static bool __no_inline_not_in_flash_func(sof_timer)(repeating_timer_t *_rt) {
     }
   }
 
+  sof_count++;
+
   // SOF counter is 11-bit
-  sof_count = (sof_count + 1) & 0x7ff;
-  sof_packet[2] = sof_count & 0xff;
-  sof_packet[3] = (calc_usb_crc5(sof_count) << 3) | (sof_count >> 8);
+  uint16_t const sof_count_11b = sof_count & 0x7ff;
+  sof_packet[2] = sof_count_11b & 0xff;
+  sof_packet[3] = (calc_usb_crc5(sof_count_11b) << 3) | (sof_count_11b >> 8);
 
   return true;
 }
@@ -300,7 +302,7 @@ static bool __no_inline_not_in_flash_func(sof_timer)(repeating_timer_t *_rt) {
 // Host Controller functions
 //--------------------------------------------------------------------+
 
-uint16_t pio_usb_host_get_frame_number(void) {
+uint32_t pio_usb_host_get_frame_number(void) {
   return sof_count;
 }
 


### PR DESCRIPTION
This PR add pio_usb_host_get_frame_number() which can be handy for tinyusb when doing delay without actually using any hw timer https://github.com/hathach/tinyusb/blob/master/src/host/usbh.c#L261

which I kind of forgot to add so far https://github.com/hathach/tinyusb/blob/master/src/portable/raspberrypi/pio_usb/hcd_pio_usb.c#L105

This also increase sof_count to 11-bit in SOF packet (previously 5-bit). 

modification is originially written by @tannewt

screenshort with frame number wrap-around 
![Screenshot from 2023-06-29 10-29-56](https://github.com/sekigon-gonnoc/Pico-PIO-USB/assets/249515/cef15939-2bb7-4b45-afbc-456521e5997a)

