### PR TITLE
add pio_usb_host_endpoint_abort_transfer()

### DIFF
--- a/src/pio_usb.c
+++ b/src/pio_usb.c
@@ -381,6 +381,8 @@ bool __no_inline_not_in_flash_func(pio_usb_ll_transfer_start)(endpoint_t *ep,
     ep->new_data_flag = false;
   }
 
+  ep->transfer_started = false;
+  ep->transfer_aborted = false;
   ep->has_transfer = true;
 
   return true;

--- a/src/pio_usb_ll.h
+++ b/src/pio_usb_ll.h
@@ -170,6 +170,8 @@ bool pio_usb_host_send_setup(uint8_t root_idx, uint8_t device_address,
 bool pio_usb_host_endpoint_transfer(uint8_t root_idx, uint8_t device_address,
                                     uint8_t ep_address, uint8_t *buffer,
                                     uint16_t buflen);
+bool pio_usb_host_endpoint_abort_transfer(uint8_t root_idx, uint8_t device_address,
+                                          uint8_t ep_address);
 
 //--------------------------------------------------------------------
 // Device Controller functions

--- a/src/usb_definitions.h
+++ b/src/usb_definitions.h
@@ -60,9 +60,9 @@ typedef struct {
   bool is_tx; // Host out or Device in
 
   volatile uint8_t ep_num;
-  volatile uint16_t size;
-  uint8_t buffer[64 + 4];
   volatile bool new_data_flag;
+  volatile uint16_t size;
+
   volatile uint8_t attr;
   volatile uint8_t interval;
   volatile uint8_t interval_counter;
@@ -70,6 +70,10 @@ typedef struct {
 
   volatile bool stalled;
   volatile bool has_transfer;
+  volatile bool transfer_started;
+  volatile bool transfer_aborted;
+
+  uint8_t buffer[64 + 4];
   uint8_t *app_buf;
   uint16_t total_len;
   uint16_t actual_len;


### PR DESCRIPTION
Sometime, it is handy for host application to abort an transfer e.g application timeout. This PR add pio_usb_host_endpoint_abort_transfer(), 2 additional bool is used to prevent race potential between the applicaiton caller and sof timer.

Note: endpoint_t struct member is also re-order a bit to have 4 bytes aligned to minimize footprint. and 2 addtional bool should not increase the struct size overally