### PR TITLE
Fix initializer syntax to not throw errors in C++.

### DIFF
--- a/src/pio_usb_configuration.h
+++ b/src/pio_usb_configuration.h
@@ -36,7 +36,7 @@ typedef struct {
     PIO_USB_DP_PIN_DEFAULT, PIO_USB_TX_DEFAULT, PIO_SM_USB_TX_DEFAULT,         \
         PIO_USB_DMA_TX_DEFAULT, PIO_USB_RX_DEFAULT, PIO_SM_USB_RX_DEFAULT,     \
         PIO_SM_USB_EOP_DEFAULT, NULL, PIO_USB_DEBUG_PIN_NONE,                  \
-        PIO_USB_DEBUG_PIN_NONE, .skip_alarm_pool = false                       \
+        PIO_USB_DEBUG_PIN_NONE, /*skip_alarm_pool=*/false                      \
   }
 
 #define PIO_USB_EP_POOL_CNT 32


### PR DESCRIPTION
C++ requires all fields to be specified for designated initializers, or for none of them to be.