### PR TITLE
Adding support for controlling the LEDs for a connected keyboard

### DIFF
--- a/src/pio_usb.h
+++ b/src/pio_usb.h
@@ -29,6 +29,9 @@ endpoint_t *pio_usb_get_endpoint(usb_device_t *device, uint8_t idx);
 int pio_usb_get_in_data(endpoint_t *ep, uint8_t *buffer, uint8_t len);
 int pio_usb_set_out_data(endpoint_t *ep, const uint8_t *buffer, uint8_t len);
 
+// Misc functions
+int pio_usb_kbd_set_leds(usb_device_t *device, uint8_t port, uint8_t value); 
+
 #ifdef __cplusplus
  }
 #endif

--- a/src/pio_usb_host.c
+++ b/src/pio_usb_host.c
@@ -1348,3 +1348,14 @@ static void __no_inline_not_in_flash_func(__pio_usb_host_irq_handler)(uint8_t ro
 void pio_usb_host_irq_handler(uint8_t root_id) __attribute__ ((weak, alias("__pio_usb_host_irq_handler")));
 
 #pragma GCC pop_options
+
+//--------------------------------------------------------------------+
+// Misc functions 
+//--------------------------------------------------------------------+
+int pio_usb_kbd_set_leds(usb_device_t *device, uint8_t port, uint8_t value) {
+  usb_setup_packet_t req = SET_REPORT_REQ_DEFAULT;
+  req.index_lsb = port;
+  req.length_lsb = 1;
+  req.length_msb = 0;
+  return control_out_protocol(device, (uint8_t *)&req, sizeof(req), &value, 1);
+}

--- a/src/usb_definitions.h
+++ b/src/usb_definitions.h
@@ -314,6 +314,8 @@ enum {
   { USB_REQ_TYP_CLASS | USB_REQ_REC_IFACE, 0x0A, 0, 0, 0, 0, 0, 0 }
 #define GET_HID_REPORT_DESCRIPTOR_DEFAULT                                      \
   { USB_REQ_DIR_IN | USB_REQ_REC_IFACE, 0x06, 0, 0x22, 0, 0, 0xff, 0 }
+#define SET_REPORT_REQ_DEFAULT                                                 \
+  { USB_REQ_TYP_CLASS | USB_REQ_REC_IFACE, 0x09, 0, 0x02, 0, 0, 0, 0 }
 #define GET_HUB_DESCRPTOR_REQUEST                                              \
   {                                                                            \
     USB_REQ_DIR_IN | USB_REQ_TYP_CLASS | USB_REQ_REC_DEVICE, 0x06, 0, 0x29, 0, \


### PR DESCRIPTION
This provides support for controlling LEDs in connected keyboards when operating as a USB host.

Needed it for a personal project, feel free to integrate where you see fit (or not). :-)