### PR TITLE
pio_usb: mask endp with b'111 (d'7)

### DIFF
--- a/src/pio_usb.c
+++ b/src/pio_usb.c
@@ -122,7 +122,7 @@ void __no_inline_not_in_flash_func(pio_usb_bus_send_token)(const pio_port_t *pp,
   uint16_t dat = ((uint16_t)(ep_num & 0xf) << 7) | (addr & 0x7f);
   uint8_t crc = calc_usb_crc5(dat);
   packet[2] = dat & 0xff;
-  packet[3] = (crc << 3) | ((dat >> 8) & 0x1f);
+  packet[3] = (crc << 3) | ((ep_num >> 1) & 0x7);
 
   uint8_t packet_encoded[sizeof(packet) * 2 * 7 / 6 + 2];
   uint8_t encoded_len = pio_usb_ll_encode_tx_data(packet, sizeof(packet), packet_encoded);


### PR DESCRIPTION
This does not fix any issue, but makes token packet creation according to the usb 2.0 spec, where the third byte contains:

```
   ENDP  CRC5
      3     5
```

so make `ENDP & 0x7` and not `ENDP & 0x1f`. This actually could be a nasty bug, but the code a few lines above makes sure that `dat` has exactly 11 bits, so incorrect mask does not make any effect.

This patch makes mask according to the spec.