### PR TITLE
retry transaction up to 3 times for usb host

### DIFF
--- a/src/pio_usb.c
+++ b/src/pio_usb.c
@@ -511,6 +511,7 @@ bool __no_inline_not_in_flash_func(pio_usb_ll_transfer_start)(endpoint_t *ep,
   ep->app_buf = buffer;
   ep->total_len = buflen;
   ep->actual_len = 0;
+  ep->failed_count = 0;
 
   if (ep->is_tx) {
     prepare_tx_data(ep);

--- a/src/pio_usb_host.c
+++ b/src/pio_usb_host.c
@@ -615,12 +615,12 @@ static int __no_inline_not_in_flash_func(usb_setup_transaction)(
   pio_usb_bus_wait_handshake(pp);
   pio_sm_set_enabled(pp->pio_usb_rx, pp->sm_rx, false);
 
-  ep->actual_len = 8;
-
   if (pp->usb_rx_buffer[0] == USB_SYNC && pp->usb_rx_buffer[1] == USB_PID_ACK) {
+    ep->actual_len = 8;
     pio_usb_ll_transfer_complete(ep, PIO_USB_INTS_ENDPOINT_COMPLETE_BITS);
   } else {
     res = -1;
+    ep->data_id = USB_PID_SETUP; // retry setup
     if (++ep->failed_count > TRANSACTION_MAX_RETRY) {
       pio_usb_ll_transfer_complete(ep, PIO_USB_INTS_ENDPOINT_ERROR_BITS);
     }

--- a/src/pio_usb_host.c
+++ b/src/pio_usb_host.c
@@ -540,7 +540,7 @@ static int __no_inline_not_in_flash_func(usb_in_transaction)(pio_port_t *pp,
       res = -2;
     }
 
-    if (++ep->failed_count > TRANSACTION_MAX_RETRY) {
+    if (++ep->failed_count >= TRANSACTION_MAX_RETRY) {
       pio_usb_ll_transfer_complete(ep, PIO_USB_INTS_ENDPOINT_ERROR_BITS); // failed after 3 consecutive retries
     }
   }
@@ -581,7 +581,7 @@ static int __no_inline_not_in_flash_func(usb_out_transaction)(pio_port_t *pp,
     pio_usb_ll_transfer_complete(ep, PIO_USB_INTS_ENDPOINT_STALLED_BITS);
   } else {
     res = -1;
-    if (++ep->failed_count > TRANSACTION_MAX_RETRY) {
+    if (++ep->failed_count >= TRANSACTION_MAX_RETRY) {
       pio_usb_ll_transfer_complete(ep, PIO_USB_INTS_ENDPOINT_ERROR_BITS);
     }
   }
@@ -621,7 +621,7 @@ static int __no_inline_not_in_flash_func(usb_setup_transaction)(
   } else {
     res = -1;
     ep->data_id = USB_PID_SETUP; // retry setup
-    if (++ep->failed_count > TRANSACTION_MAX_RETRY) {
+    if (++ep->failed_count >= TRANSACTION_MAX_RETRY) {
       pio_usb_ll_transfer_complete(ep, PIO_USB_INTS_ENDPOINT_ERROR_BITS);
     }
   }

--- a/src/usb_definitions.h
+++ b/src/usb_definitions.h
@@ -75,6 +75,8 @@ typedef struct {
 
   uint8_t buffer[(64 + 4) * 2 * 7 / 6 + 2];
   uint8_t encoded_data_len;
+  uint8_t failed_count;
+
   uint8_t *app_buf;
   uint16_t total_len;
   uint16_t actual_len;


### PR DESCRIPTION
Testing with pio-usb as host with hub device, when plugging and unplugging device from hub, the bus can have some interruption and can cause on-going transaction to fail. Not all class driver handle failed transaction nicely. However, most of the time, a couple of retry in the next frame would solve the issue without escalate it to driver (to re-schedule transfer).

This should help to address #149 and #148. I will mark this as ready after doing more entensive tests. If anyone can help to provide feedback, that would be great.    

related issue: https://github.com/hathach/tinyusb/pull/2994 enhance hub driver and control transfer to also re-schedule failed transfer as well.

PS: Testing more and it does improve hub with multiple plug/unplug. Therefore this is ready for review

@tannewt @ladyada