### PR TITLE
quick & dirty timeout changes make rp2350 @ 264MHz work better

### DIFF
--- a/src/pio_usb.c
+++ b/src/pio_usb.c
@@ -144,7 +144,7 @@ void __no_inline_not_in_flash_func(pio_usb_bus_start_receive)(const pio_port_t *
 }
 
 uint8_t __no_inline_not_in_flash_func(pio_usb_bus_wait_handshake)(pio_port_t* pp) {
-  int16_t t = 240;
+  int16_t t = 240*4;
   int16_t idx = 0;
 
   while (t--) {
@@ -176,9 +176,9 @@ int __no_inline_not_in_flash_func(pio_usb_bus_receive_packet_and_handshake)(
   uint16_t crc_receive = 0xffff;
   uint16_t crc_receive_inverse;
   bool crc_match = false;
-  int16_t t = 240;
+  int16_t t = 240*4;
   uint16_t idx = 0;
-  uint16_t nak_timeout = 10000;
+  uint32_t nak_timeout = 40000;
   const uint16_t rx_buf_len = sizeof(pp->usb_rx_buffer) / sizeof(pp->usb_rx_buffer[0]);
 
   while (t--) {


### PR DESCRIPTION
it's able to enumerate a random LS keyboard while also running dvhstx text mode on an Adafruit Metro RP2350.

As discussed in the Adafruit slack, the RP2350 overclocked to 240MHz or 264MHz does not successfully enumerate the LS devices I tested it with, such as a logitech-branded keyboard (046d:3c13 LITEON Technology USB Multimedia Keyboard). This particular keyboard WOULD enumerate when running at 120MHz, but not at 240MHz or 264MHz.

I suspect but don't know for certain that this can be reproduced on any old RP2350 running at 240MHz, though I didn't try anything except the Metro.

@tannewt had the insight that there are some hard coded timing delays and countdowns. I changed these three timeouts, arbitrarily increasing them by 4x, and my keyboard started enumerating. I haven't done any further testing yet to see whether it functions properly when sending HID reports and I don't have any sophisticated USB protocol scoping equipment like @hathach does to check what's actually on the bus.

I think @tannewt is interested in preparing a "proper" patch that actually checks the CPU speed to set a correct timeout, so this PR should probably not be merged. However, while there's not a proper fix I wanted to share my "working" code in case it benefits others.