### PR TITLE
Not all RP2040 / RP2350 Boards have a LED

### DIFF
--- a/examples/test_ll/test_ll.c
+++ b/examples/test_ll/test_ll.c
@@ -45,7 +45,11 @@ int main() {
     scanf("%c", &c);
 
     if (c == 'b') {
+#ifdef PICO_DEFAULT_LED_PIN
       reset_usb_boot(1 << PICO_DEFAULT_LED_PIN, 0);
+#else
+      reset_usb_boot(0, 0);
+#endif
     }
 
     {


### PR DESCRIPTION
This is just a little fix to the test_ll example - not all possible boards have a LED which is configured using the preprocessor variable PICO_DEFAULT_LED_PIN.