### PR TITLE
fix(hcd) pio_usb_host_endpoint_open() return true if endpoint is already opened

### DIFF
--- a/src/pio_usb_host.c
+++ b/src/pio_usb_host.c
@@ -425,7 +425,7 @@ bool pio_usb_host_endpoint_open(uint8_t root_idx, uint8_t device_address,
                                 uint8_t const *desc_endpoint, bool need_pre) {
   const endpoint_descriptor_t *d = (const endpoint_descriptor_t *)desc_endpoint;
   if (NULL != _find_ep(root_idx, device_address, d->epaddr)) {
-    return false; // endpoint already opened
+    return true; // already opened
   }
   for (int ep_pool_idx = 0; ep_pool_idx < PIO_USB_EP_POOL_CNT; ep_pool_idx++) {
     endpoint_t *ep = PIO_USB_ENDPOINT(ep_pool_idx);


### PR DESCRIPTION
I channge the return value of pio_usb_host_endpoint_open() when endpoint is alreaady opened. It make more sense since endpoint is ready to make transfer anyway.