### PR TITLE
Fix host issue with with turnaround (inter-packet) timing

### DIFF
--- a/src/pio_usb.c
+++ b/src/pio_usb.c
@@ -97,8 +97,17 @@ void __not_in_flash_func(pio_usb_bus_usb_transfer)(pio_port_t *pp,
     continue;
   }
   pp->pio_usb_tx->irq = IRQ_TX_ALL_MASK; // clear complete flag
-  while (*pc <= PIO_USB_TX_ENCODED_DATA_COMP) {
+  while (*pc < PIO_USB_TX_ENCODED_DATA_COMP) {
     continue;
+  }
+
+  // For Low speed host, wait until EOP is fully sent. Otherwise, we can send another packet
+  // before inter-packet delay timeout, which is 2-bit time by USB specs.
+  // For Full speed, our overhead is probably enough without this additional wait.
+  if (pp->low_speed) {
+    while (*pc <= PIO_USB_TX_ENCODED_DATA_COMP) {
+      continue;
+    }
   }
 }
 

--- a/src/pio_usb.c
+++ b/src/pio_usb.c
@@ -97,15 +97,16 @@ void __not_in_flash_func(pio_usb_bus_usb_transfer)(pio_port_t *pp,
     continue;
   }
   pp->pio_usb_tx->irq = IRQ_TX_ALL_MASK; // clear complete flag
-  while (*pc < PIO_USB_TX_ENCODED_DATA_COMP) {
-    continue;
-  }
 
-  // For Low speed host, wait until EOP is fully sent. Otherwise, we can send another packet
-  // before inter-packet delay timeout, which is 2-bit time by USB specs.
-  // For Full speed, our overhead is probably enough without this additional wait.
   if (pp->low_speed) {
+    // For Low speed host, wait until EOP is fully sent. Otherwise, we can send another packet
+    // before inter-packet delay timeout, which is 2-bit time by USB specs.
+    // For Full speed, our overhead is probably enough without this additional wait.
     while (*pc <= PIO_USB_TX_ENCODED_DATA_COMP) {
+      continue;
+    }
+  } else {
+    while (*pc < PIO_USB_TX_ENCODED_DATA_COMP) {
       continue;
     }
   }

--- a/src/pio_usb.c
+++ b/src/pio_usb.c
@@ -97,7 +97,7 @@ void __not_in_flash_func(pio_usb_bus_usb_transfer)(pio_port_t *pp,
     continue;
   }
   pp->pio_usb_tx->irq = IRQ_TX_ALL_MASK; // clear complete flag
-  while (*pc < PIO_USB_TX_ENCODED_DATA_COMP) {
+  while (*pc <= PIO_USB_TX_ENCODED_DATA_COMP) {
     continue;
   }
 }
@@ -206,6 +206,19 @@ int __no_inline_not_in_flash_func(pio_usb_bus_receive_packet_and_handshake)(
   const uint16_t rx_buf_len = sizeof(pp->usb_rx_buffer) / sizeof(pp->usb_rx_buffer[0]);
   int16_t idx = 0;
 
+  // Per USB Specs 7.1.18 for turnaround: We must wait at least 2 bit times for inter-packet delay.
+  // This is essential for working with LS device specially when we overlocked the mcu.
+  // Pre-calculate number of cycle per bit time
+  // - Lowspeed: 1 bit time = (cpufreq / 1.5 Mhz) = clk_div_ls_tx.div_int*6Mhz / 1.5 Mhz = 4 * clk_div_ls_tx.div_int
+  // - Fullspeed 1 bit time = (cpufreq / 12 Mhz) = clk_div_fs_tx.div_int*48Mhz / 12 Mhz = 4 * clk_div_fs_tx.div_int
+  // Since there is also overhead, we only wait 1.5 bit for LS and 1 bit for FS
+  uint32_t turnaround_in_cycle;
+  if (pp->low_speed) {
+    turnaround_in_cycle = 6 * pp->clk_div_ls_tx.div_int; // 1.5 bit time
+  } else {
+    turnaround_in_cycle = 4 * pp->clk_div_fs_tx.div_int; // 1 bit time
+  }
+
   // Timeout in seven microseconds. That is enough time to receive one byte at low speed.
   // This is to detect packets without an EOP because the device was unplugged.
   uint32_t start = get_time_us_32();
@@ -227,8 +240,10 @@ int __no_inline_not_in_flash_func(pio_usb_bus_receive_packet_and_handshake)(
       }
       idx++;
     } else if ((pp->pio_usb_rx->irq & IRQ_RX_COMP_MASK) != 0) {
-      // Exit early if we've gotten an EOP. There *might* be a race between EOP
-      // detection and NRZI decoding but it is unlikely.
+      // Exit since we've gotten an EOP.
+      // Timing critical: per USB specs, handshake must be sent within 2-7 bit-time strictly
+      busy_wait_at_least_cycles(turnaround_in_cycle); // wait for turnaround
+
       if (handshake == USB_PID_ACK) {
         // Only ACK if crc matches
         if (idx >= 4 && crc_match) {

--- a/src/pio_usb_ll.h
+++ b/src/pio_usb_ll.h
@@ -148,6 +148,9 @@ pio_usb_bus_get_line_state(root_port_t *root) {
     gpio_set_input_enabled(root->pin_dp, false);
     gpio_set_input_enabled(root->pin_dm, false);
 
+    // short delay to drain leaked current, required when overclocked CPU, tested with 264Mhz
+    __asm volatile("nop; nop; nop; nop; nop; nop; nop; nop;");
+
     gpio_set_input_enabled(root->pin_dp, true);
     gpio_set_input_enabled(root->pin_dm, true);
   }

--- a/src/pio_usb_ll.h
+++ b/src/pio_usb_ll.h
@@ -141,6 +141,18 @@ void pio_usb_bus_send_token(pio_port_t *pp, uint8_t token, uint8_t addr,
 
 static __always_inline port_pin_status_t
 pio_usb_bus_get_line_state(root_port_t *root) {
+#ifdef PICO_RP2350
+  // RP2350-E9 Errata affect up to rev A2/B0
+  // workaround: disable input enable (to drain leaked current), then enable it immediately before reading
+  if (rp2350_chip_version() <= 2) {
+    gpio_set_input_enabled(root->pin_dp, false);
+    gpio_set_input_enabled(root->pin_dm, false);
+
+    gpio_set_input_enabled(root->pin_dp, true);
+    gpio_set_input_enabled(root->pin_dm, true);
+  }
+#endif
+
   uint8_t dp = gpio_get(root->pin_dp) ? 0 : 1;
   uint8_t dm = gpio_get(root->pin_dm) ? 0 : 1;
 


### PR DESCRIPTION
USB 2.0 specs 7.1.18 specify 2 bit time for inter-packet, especially when switching bus direction.
![image](https://github.com/user-attachments/assets/37faafab-596a-4e75-a86f-891d628cf1f8)

This is essential when we overlock mcu to higher clock such as 240/264 Mhz. We basically send handshake too fast after EOP and give device no time to capture the bus correcly. This also occurs with some slow device such as LS gamepad in https://github.com/adafruit/circuitpython/issues/10243
 
`turnaround` delay is done in cycle which is conveniently = 4 pp->clk_div_/fsls_tx.div_int. Since we also have overhead, I think it is best to do 1.5 bit time for LS and 1 bit time for FS.

- I also notice that we mistakenly send SOF instead of Keep-alive on the LS bus, therefore fix it as well. 

@tannewt @FoamyGuy @ladyada Please try to see if this fixes your issue with gamepad (direct attached) and 264Mhz overclocked with hub + mouse + keyboard on fruit jam

PS: Also include the ~fix~ workaround for the famous RP2350-E9. all rp2350 A2/B0 cannot reliably read gpio when floating. This is the root cause that pio host cannot detect the device disconnection ((floating), when it tries to read line state, it is always get J state instead of SE0. 
![image](https://github.com/user-attachments/assets/a98b0319-f2a3-4f90-a9f6-6d2958f412b6)
![image](https://github.com/user-attachments/assets/c2a2e179-8e34-46ad-9d85-03ca5d36d93d)

