### PR TITLE
optimize to reduce delay between received DATA and sending handshake

### DIFF
--- a/src/pio_usb_ll.h
+++ b/src/pio_usb_ll.h
@@ -136,7 +136,6 @@ void pio_usb_bus_usb_transfer(pio_port_t *pp, uint8_t *data,
                               uint16_t len);
 
 uint8_t pio_usb_bus_wait_handshake(pio_port_t *pp);
-void pio_usb_bus_send_handshake(pio_port_t *pp, uint8_t pid);
 void pio_usb_bus_send_token(pio_port_t *pp, uint8_t token, uint8_t addr,
                             uint8_t ep_num);
 


### PR DESCRIPTION
This PR optimizes `pio_usb_bus_receive_packet_and_handshake()` to reduce the delay between received EOP and sending handshake packet. The issue occurs while running pio-usb on rp2040 @120Mhz enumerating rp2350 bootrom. rp2350 bootrom/usb controller is correctly picky and raise RX_TIMEOUT when handshake isn't send in time. Look like its timeout is around **1.167us-1.2us** (x2 specs) or so. Recently PRs probably introduce addtional logic/delay also rp2350 has tighter time out than other.

Note: Per USB specs handshake must be sent within 2-7 bit-time strictly, 1-bit time in FS is 83.3 ns --> handshake delay is **166ms-583ns**.

This may fix enumeration with other device as well 

**Before PR**
EOP to ACK is **1.249us** (idle time of the IN packet), rp2350 considered it timeo-out and does not count the IN transfer as complete, therefore NAK all following OUT (of the control status), while our host driver, it is already complete successfully.
<img width="1759" height="624" alt="Screenshot from 2025-07-29 21-36-20" src="https://github.com/user-attachments/assets/f2f7a2cd-96c3-4590-a766-82468e87715a" />

**After PR**
EOP to ACK is reduced to sub 1us (950ns) and all transfer is carried out successfully.
<img width="1759" height="624" alt="Screenshot from 2025-07-30 12-19-54" src="https://github.com/user-attachments/assets/4d9ef2cf-40ce-4216-acda-bed441d063cb" />

@ladyada