### PR TITLE
Use request length when handling device descriptor request.

### DIFF
--- a/examples/usb_device/usb_device.c
+++ b/examples/usb_device/usb_device.c
@@ -125,7 +125,7 @@ void core1_main() {
 
 int main() {
   // default 125MHz is not appropreate. Sysclock should be multiple of 12MHz.
-  set_sys_clock_khz(120000, true);
+  set_sys_clock_khz(180000, true);
 
   stdio_init_all();
   printf("hello!");

--- a/src/pio_usb_device.c
+++ b/src/pio_usb_device.c
@@ -449,7 +449,11 @@ static int __no_inline_not_in_flash_func(process_device_setup_stage)(uint8_t *bu
   if (packet->request_type == USB_REQ_DIR_IN) {
     if (packet->request == 0x06) {
       if (packet->value_msb == DESC_TYPE_DEVICE) {
-        prepare_ep0_data((uint8_t *)descriptor_buffers.device, 18);
+        uint16_t req_len = (packet->length_lsb | (packet->length_msb << 8));
+        uint16_t desc_len =
+          descriptor_buffers.config[2] | (descriptor_buffers.config[3] << 8);
+        req_len = req_len > desc_len ? desc_len : req_len;
+        prepare_ep0_data((uint8_t *)descriptor_buffers.device, req_len);
         res = 0;
       } else if (packet->value_msb == DESC_TYPE_CONFIG) {
         ep0_desc_request_len = (packet->length_lsb | (packet->length_msb << 8));


### PR DESCRIPTION
Fixes #196, Apple seems to request the descriptor in chunks. Hard coding the response at 18 bytes causes OSX to stop enumeration and disable the device. 

Additionally, I changed the clock speed in the usb_device example to 180MHz, with these changes the example successfully enumerates on both my M2 mac air and my AMD linux machine.