### PR TITLE
Fix/host busy wait hangs

### DIFF
--- a/src/pio_usb.c
+++ b/src/pio_usb.c
@@ -92,8 +92,27 @@ void __not_in_flash_func(pio_usb_bus_usb_transfer)(pio_port_t *pp,
   dma_channel_transfer_from_buffer_now(pp->tx_ch, data, len);
   pp->pio_usb_tx->irq = IRQ_TX_ALL_MASK; // clear complete flag
 
+  // Bounded wait on the TX completion flag. `len` pre-encoded bytes shift
+  // out at the wire bit rate (full speed: len*8/12MHz us, low speed: 8x),
+  // so a legitimate transfer can never approach this budget. The fixed
+  // 1000 us component covers wall-clock preemption when a transfer is
+  // issued from task context and the 1 ms frame interrupt runs in between.
+  // On expiry, abort the DMA and restart the TX state machine so the next
+  // transfer starts from a clean state; the lost transaction is retried by
+  // the USB protocol.
+  uint32_t const expected_us =
+      pp->low_speed ? (len * 16u) / 3u + 1u : (len * 2u) / 3u + 1u;
+  uint32_t const timeout_us = 1000u + 4u * expected_us;
+  uint32_t const start_us = get_time_us_32();
   while ((pp->pio_usb_tx->irq & IRQ_TX_ALL_MASK) == 0) {
-    continue;
+    if (get_time_us_32() - start_us > timeout_us) {
+      dma_channel_abort(pp->tx_ch);
+      pio_sm_set_enabled(pp->pio_usb_tx, pp->sm_tx, false);
+      pio_sm_clear_fifos(pp->pio_usb_tx, pp->sm_tx);
+      pio_sm_restart(pp->pio_usb_tx, pp->sm_tx);
+      pio_sm_set_enabled(pp->pio_usb_tx, pp->sm_tx, true);
+      return;
+    }
   }
   pp->pio_usb_tx->irq = IRQ_TX_ALL_MASK; // clear complete flag
 
@@ -233,8 +252,17 @@ int __no_inline_not_in_flash_func(pio_usb_bus_receive_packet_and_handshake)(
 
   // Timeout in seven microseconds. That is enough time to receive one byte at low speed.
   // This is to detect packets without an EOP because the device was unplugged.
+  //
+  // The 7 us timeout resets on every received byte, so a babbling bus or a
+  // wedged RX state machine that keeps producing data holds this loop
+  // forever (#192). Add an absolute deadline: the longest legitimate packet
+  // (64 B data, low speed, bit-stuffed) ends well under 500 us.
+  uint32_t const abs_start = get_time_us_32();
   uint32_t start = get_time_us_32();
   while (1) {
+    if (get_time_us_32() - abs_start > 500) {
+      return -1;
+    }
     if (pio_sm_get_rx_fifo_level(pio_usb_rx, sm_rx)) {
       uint8_t data = pio_sm_get(pio_usb_rx, sm_rx) >> 24;
       if (idx < rx_buf_len) {

--- a/src/pio_usb.c
+++ b/src/pio_usb.c
@@ -142,6 +142,18 @@ void __no_inline_not_in_flash_func(pio_usb_bus_prepare_receive)(const pio_port_t
   pio_sm_exec(pp->pio_usb_rx, pp->sm_rx, pp->rx_reset_instr);
   pio_sm_exec(pp->pio_usb_rx, pp->sm_rx, pp->rx_reset_instr2);
   pio_sm_set_enabled(pp->pio_usb_rx, pp->sm_rx, true);
+
+  // Also re-initialize the EOP/edge-detector SM. Only sm_rx was reset here,
+  // so a wedged sm_eop persisted across transactions: every subsequent IN
+  // fails silently (no RX-start flag is ever raised) while the rest of the
+  // stack looks healthy — RX flatlines until an external reset. Jumping to
+  // the program entry (`irq wait IRQ_RX_EOP` at offset_eop) reproduces the
+  // state pio_sm_init() establishes; the flag it raises is cleared by the
+  // pio_usb_bus_start_receive() that follows every prepare.
+  pio_sm_set_enabled(pp->pio_usb_rx, pp->sm_eop, false);
+  pio_sm_restart(pp->pio_usb_rx, pp->sm_eop);
+  pio_sm_exec(pp->pio_usb_rx, pp->sm_eop, pio_encode_jmp(pp->offset_eop));
+  pio_sm_set_enabled(pp->pio_usb_rx, pp->sm_eop, true);
 }
 
 static inline __force_inline bool pio_usb_bus_wait_for_rx_start(const pio_port_t* pp) {

--- a/src/pio_usb.c
+++ b/src/pio_usb.c
@@ -92,24 +92,30 @@ void __not_in_flash_func(pio_usb_bus_usb_transfer)(pio_port_t *pp,
   dma_channel_transfer_from_buffer_now(pp->tx_ch, data, len);
   pp->pio_usb_tx->irq = IRQ_TX_ALL_MASK; // clear complete flag
 
-  io_ro_32 *pc = &pp->pio_usb_tx->sm[pp->sm_tx].addr;
   while ((pp->pio_usb_tx->irq & IRQ_TX_ALL_MASK) == 0) {
     continue;
   }
   pp->pio_usb_tx->irq = IRQ_TX_ALL_MASK; // clear complete flag
 
-  if (pp->low_speed) {
-    // For Low speed host, wait until EOP is fully sent. Otherwise, we can send another packet
-    // before inter-packet delay timeout, which is 2-bit time by USB specs.
-    // For Full speed, our overhead is probably enough without this additional wait.
-    while (*pc <= PIO_USB_TX_ENCODED_DATA_COMP) {
-      continue;
-    }
-  } else {
-    while (*pc < PIO_USB_TX_ENCODED_DATA_COMP) {
-      continue;
-    }
-  }
+  // Wait out the EOP tail deterministically instead of polling the state
+  // machine's program counter. The previous pc-polling loop
+  //   while (*pc < PIO_USB_TX_ENCODED_DATA_COMP) {}
+  // is a sampling race: after raising IRQ_TX_EOP the SM spends only ~3
+  // bit-times (about 250 ns at full speed) in the EOP address region before
+  // wrapping back below PIO_USB_TX_ENCODED_DATA_COMP to park on the
+  // `out pc, 2` instruction. If the CPU's polling never samples that brief
+  // window the exit condition is never observed and the core spins forever.
+  //
+  // The tail length after the completion IRQ is fixed (2xSE0 within the irq
+  // instruction, then J, then bus release), so wait 4 bit-times. This wait
+  // must stay short: for IN transactions the device may answer as early as
+  // 2 bit-times after EOP end, and callers arm the RX state machine only
+  // after this function returns.
+  //
+  // 1 bit-time = 4 CPU cycles * clkdiv (the TX SM runs 4 cycles per bit).
+  uint32_t const bit_cycles = 4u * (pp->low_speed ? pp->clk_div_ls_tx.div_int
+                                                  : pp->clk_div_fs_tx.div_int);
+  busy_wait_at_least_cycles(4u * bit_cycles);
 }
 
 void __no_inline_not_in_flash_func(pio_usb_bus_send_token)(pio_port_t *pp,

--- a/src/pio_usb_host.c
+++ b/src/pio_usb_host.c
@@ -224,6 +224,22 @@ static bool __no_inline_not_in_flash_func(connection_check)(root_port_t *port) {
     busy_wait_1_us();
 
     if (pio_usb_bus_get_line_state(port) == PORT_PIN_SE0) {
+      // Require SE0 to persist for ~100 us before believing the disconnect.
+      // A real unplug holds SE0 for milliseconds, but the previous 2 us
+      // filter also passed short EMI/crosstalk glitches. The resulting
+      // spurious DISCONNECT (often followed by a CONNECT in the same or
+      // next frame, since the device never left) corrupts the host stack's
+      // device state: endpoints are closed while the device is still
+      // considered mounted and all traffic stops until an external reset.
+      // Observed roughly once per 2 hours on a full-speed MIDI host bench.
+      for (int confirm = 0; confirm < 20; confirm++) {
+        for (int w = 0; w < 5; w++) {
+          busy_wait_1_us();
+        }
+        if (pio_usb_bus_get_line_state(port) != PORT_PIN_SE0) {
+          return true; // glitch, still connected
+        }
+      }
       busy_wait_1_us();
       // device disconnect
       port->connected = false;

--- a/src/pio_usb_ll.h
+++ b/src/pio_usb_ll.h
@@ -167,8 +167,17 @@ pio_usb_bus_get_line_state(root_port_t *root) {
 
 static __always_inline void pio_usb_bus_start_receive(const pio_port_t *pp) {
   pp->pio_usb_rx->irq = IRQ_RX_ALL_MASK;
-  while ((pp->pio_usb_rx->irq & IRQ_RX_ALL_MASK) != 0) {
-    continue;
+  // Bounded wait: a wedged or babbling RX/EOP state machine can re-raise
+  // its IRQ flag continuously (observed after a bus reset), which turns
+  // this clear-wait into an infinite spin on the host core. Normal
+  // clearing is immediate; give a generous spin budget (~1 ms) and proceed
+  // regardless — the transaction then fails cleanly through the existing
+  // retry/error path instead of hanging the core.
+  for (uint32_t guard = 0;
+       (pp->pio_usb_rx->irq & IRQ_RX_ALL_MASK) != 0; guard++) {
+    if (guard > 50000) {
+      break;
+    }
   }
 }
 


### PR DESCRIPTION
# Fix host-mode core hangs: unbounded busy-waits and an EOP polling race

Fixes several ways the PIO USB host can hang its core forever or silently
stop communicating. Likely fixes #197 and #203, addresses #192.

## Changes

1. **`usb_transfer`: fix EOP wait sampling race** — the end-of-packet wait
   polled the TX state machine's program counter, but after `IRQ_TX_EOP`
   the SM stays in the EOP address region for only ~3 bit-times (~250 ns
   at full speed) before wrapping back below the marker. Miss that window
   and the loop spins forever. Replaced with a deterministic 4-bit-time
   wait derived from the SM clock divider. Kept below the device response
   turnaround (USB 2.0 §7.1.18: min. 2 bit-times after EOP), since callers
   arm the RX state machine only after this returns. Fixes #197, #203.

2. **Debounce disconnect detection** — 2 µs of SE0 was treated as a
   disconnect; short bus glitches pass that filter and the spurious
   disconnect/connect pair corrupts device state (endpoints closed, device
   still "mounted", traffic dead). Now requires ~100 µs of persistent SE0.
   A real detach holds SE0 indefinitely, so detection is merely ~100 µs
   later.

3. **Bound `start_receive` flag-clear wait** — spins forever if a wedged
   RX/EOP state machine keeps re-raising an IRQ flag. Bounded (~1 ms);
   on expiry the transaction fails through the existing retry path.

4. **Reinit `sm_eop` in `prepare_receive`** — only `sm_rx` was reset per
   transaction; a wedged EOP detector persisted forever and silently
   killed all IN traffic.

5. **Bound remaining waits** — TX completion-IRQ wait gets a timeout
   (4× wire time + 1 ms) with DMA abort + SM restart on expiry;
   `receive_packet_and_handshake` gets an absolute 500 µs deadline — its
   7 µs timeout resets per received byte, so a babbling bus holds it
   forever (#192).

## Testing

RP2040 @ 240 MHz, full-speed USB MIDI host under continuous verified
bidirectional traffic: previously a hard core hang within ~20 min,
reliably (hangs PC-sampled to the loops in commit 1). With these fixes:
62 h / 6.4 M packets, zero hangs, zero message loss.

Low-speed path patched symmetrically but untested; RP2350 untested;
device mode untouched.