### PR TITLE
Place calc_usb_crc16 in RAM like calc_usb_crc5 and the CRC tables

### DIFF
--- a/src/usb_crc.c
+++ b/src/usb_crc.c
@@ -52,7 +52,7 @@ const uint16_t __not_in_flash("crc_tbl") crc16_tbl[256] = {
     0x4540, 0x8701, 0x47c0, 0x4680, 0x8641, 0x8201, 0x42c0, 0x4380, 0x8341,
     0x4100, 0x81c1, 0x8081, 0x4040};
 
-uint16_t calc_usb_crc16(const uint8_t *data, uint16_t len) {
+uint16_t __not_in_flash_func(calc_usb_crc16)(const uint8_t *data, uint16_t len) {
   uint16_t crc = 0xffff;
 
   for (int idx = 0; idx < len; idx++) {


### PR DESCRIPTION
`crc16_tbl`, `crc5_tbl`, and `calc_usb_crc5` are all marked not-in-flash, but `calc_usb_crc16` itself was left in flash. It gets called from `prepare_tx_data` when continuing multi-packet OUT transfers, which runs on the USB core. On hosts that block that core from touching flash (CircuitPython RP2040/RP2350 boards do), the first big OUT transfer, like writing to a USB drive, hard faults the core and USB locks up.

One-word fix: add `__not_in_flash_func` to match its neighbors.

Verified on an Adafruit Feather RP2040 USB Host: a 512-byte SCSI WRITE(10) locks the board without this change and completes with it. Found by a static checker that walks the core1 call graph for flash-resident callees (adafruit/circuitpython#11115), part of the investigation in adafruit/circuitpython#10243.