### PR TITLE
Clamp received packet length before memcpy in IN/OUT handlers

### DIFF
--- a/src/pio_usb_device.c
+++ b/src/pio_usb_device.c
@@ -211,6 +211,14 @@ static void __no_inline_not_in_flash_func(usb_device_packet_handler)(void) {
 
     if (ep->has_transfer) {
       if (res >= 0) {
+        // Clamp to the transaction length the device actually allocated a
+        // buffer for. A non-compliant or malicious host could otherwise send
+        // an OUT packet larger than ep->app_buf, causing an out-of-bounds
+        // memcpy.
+        uint16_t const xact_len = pio_usb_ll_get_transaction_len(ep);
+        if ((uint16_t)res > xact_len) {
+          res = xact_len;
+        }
         memcpy(ep->app_buf, pp->usb_rx_buffer + 2, res);
         pio_usb_ll_transfer_continue(ep, res);
       }

--- a/src/pio_usb_host.c
+++ b/src/pio_usb_host.c
@@ -548,6 +548,14 @@ static int __no_inline_not_in_flash_func(usb_in_transaction)(pio_port_t *pp,
 
   if (receive_len >= 0) {
     if (receive_pid == expect_pid) {
+      // Clamp to the transaction length the host actually requested/allocated
+      // a buffer for. A non-compliant or malicious device could otherwise
+      // report a receive_len larger than ep->app_buf (or usb_rx_buffer),
+      // causing an out-of-bounds memcpy.
+      uint16_t const xact_len = pio_usb_ll_get_transaction_len(ep);
+      if ((uint16_t)receive_len > xact_len) {
+        receive_len = xact_len;
+      }
       memcpy(ep->app_buf, &pp->usb_rx_buffer[2], receive_len);
       pio_usb_ll_transfer_continue(ep, receive_len);
     } else {


### PR DESCRIPTION
## Problem

`pio_usb_bus_receive_packet_and_handshake()` returns the number of data bytes it parsed out of a received USB packet, but that value is never clamped to the transaction length the endpoint actually asked for.

- Host side: in `usb_in_transaction()` (`src/pio_usb_host.c`), `receive_len` is used directly:
  ```c
  int receive_len = pio_usb_bus_receive_packet_and_handshake(pp, USB_PID_ACK);
  ...
  memcpy(ep->app_buf, &pp->usb_rx_buffer[2], receive_len);
  ```
- Device side: in the OUT-token handler (`src/pio_usb_device.c`), the analogous `res` is used directly:
  ```c
  int res = pio_usb_bus_receive_packet_and_handshake(pp, handshake);
  ...
  memcpy(ep->app_buf, pp->usb_rx_buffer + 2, res);
  ```

A non-compliant or malicious peer (a rogue USB device when this stack is acting as host, or a rogue host when it is acting as device) can send a DATA packet whose payload is longer than the transfer the caller actually requested/allocated a buffer for, while still keeping the packet's CRC16 self-consistent. In that case `receive_len`/`res` comes back larger than `ep->app_buf`'s real size, and the `memcpy` above writes past it — an attacker-controlled out-of-bounds write.

This is asymmetric with the existing OUT-path convention: `pio_usb_ll_get_transaction_len(ep)` (already defined in `pio_usb_ll.h` and already used for outgoing transactions in both files) computes `min(remaining, ep->size)`, but nothing analogous is applied on the receive side before the `memcpy`.

## Fix

Clamp `receive_len` / `res` to `pio_usb_ll_get_transaction_len(ep)` immediately before the `memcpy` / `pio_usb_ll_transfer_continue()` call, in both `usb_in_transaction()` (`src/pio_usb_host.c`) and the device OUT handler (`src/pio_usb_device.c`), mirroring the bound already applied on the OUT/transmit path.

## Testing

Verified against current `main` (`a5a2f5a`). Built a standalone host-side (gcc, no target hardware) harness that reproduces the exact control flow of `pio_usb_bus_receive_packet_and_handshake()` plus the vulnerable `memcpy` line, using the real CRC16 routines from `src/usb_crc.c` to construct a byte-valid malicious DATA1 packet claiming a payload longer than the endpoint's expected transfer size:

- Without the clamp: a canary placed immediately after the destination buffer is corrupted with attacker-controlled bytes from the oversized payload, confirming a genuine out-of-bounds write.
- With the clamp applied (as in this PR): the length is clamped down to the endpoint's actual transaction length, the memcpy stays within bounds, and the canary remains intact.

Local hardware build/flash was not performed (no RP2040 toolchain available in this environment), but the change is a minimal, self-contained bound check using an existing helper function already relied upon elsewhere in the same files, with no change to control flow, timing, or non-error-path behavior.