### PR TITLE
Bound the receive loop and never ACK truncated packets

### DIFF
--- a/src/pio_usb.c
+++ b/src/pio_usb.c
@@ -191,7 +191,10 @@ int __no_inline_not_in_flash_func(pio_usb_bus_receive_packet_and_handshake)(
   uint16_t crc_receive = 0xffff;
   bool crc_match = false;
   const uint16_t rx_buf_len = sizeof(pp->usb_rx_buffer) / sizeof(pp->usb_rx_buffer[0]);
-  int16_t idx = 0;
+  // idx keeps counting past rx_buf_len (only the store is bounds checked, so
+  // the CRC keeps rolling). Unsigned so that if it ever wraps it indexes back
+  // into the buffer instead of going negative and writing below it.
+  uint16_t idx = 0;
 
   // Per USB Specs 7.1.18 for turnaround: We must wait at least 2 bit times for inter-packet delay.
   // This is essential for working with LS device specially when we overlocked the mcu.
@@ -216,6 +219,12 @@ int __no_inline_not_in_flash_func(pio_usb_bus_receive_packet_and_handshake)(
   // Timeout in seven microseconds. That is enough time to receive one byte at low speed.
   // This is to detect packets without an EOP because the device was unplugged.
   uint32_t start = get_time_us_32();
+  // Absolute deadline for the whole reception. The 7 us timeout below resets
+  // on every received byte, so a continuously toggling line (babble, or a
+  // disrupted timer per issue #192) can otherwise keep this loop running
+  // forever and overflow idx. The longest legal full-speed packet is ~685 us;
+  // 1200 us leaves margin.
+  uint32_t rx_start = start;
   while (1) {
     if (pio_sm_get_rx_fifo_level(pio_usb_rx, sm_rx)) {
       uint8_t data = pio_sm_get(pio_usb_rx, sm_rx) >> 24;
@@ -241,7 +250,9 @@ int __no_inline_not_in_flash_func(pio_usb_bus_receive_packet_and_handshake)(
 
       if (handshake == USB_PID_ACK) {
         // Only ACK if crc matches
-        if (idx >= 4 && crc_match) {
+        // Never ACK a packet longer than the buffer: bytes were dropped, so
+        // the stored data is truncated even if the rolling CRC matched.
+        if (idx >= 4 && idx <= rx_buf_len && crc_match) {
           pio_usb_bus_usb_transfer(pp, ack_encoded, 5);
           return idx - 4;
         }
@@ -251,8 +262,9 @@ int __no_inline_not_in_flash_func(pio_usb_bus_receive_packet_and_handshake)(
         pio_usb_bus_usb_transfer(pp, stall_encoded, 5);
       }
       break;
-    } else if (get_time_us_32() - start > 7) {
-      return -1; // device is probably unplugged
+    } else if (get_time_us_32() - start > 7 ||
+               get_time_us_32() - rx_start > 1200) {
+      return -1; // device is probably unplugged, or the line is babbling
     }
   }
 


### PR DESCRIPTION
Fixes the permanent host lockup in #192.

The inter-byte timeout in `pio_usb_bus_receive_packet_and_handshake` resets on every received byte, so a disrupted timer or a babbling line can keep the receive loop running with no exit while `idx` counts past the buffer.

The fix adds an absolute 1200 us deadline for the whole reception. The longest legal full speed packet is about 685 us, so real transfers are unaffected. Two small hardening changes ride along, explained in code comments: `idx` becomes unsigned, and packets longer than the rx buffer are never ACKed.

Tested on an Adafruit Fruit Jam (RP2350), same board as the #192 reporter, using the flash write simulator from that issue running continuously. A MacroPad on the hub ran a small self reset loop to replug itself every 20 seconds for enumeration traffic. Observed over SWD with a debug probe, watching the enumeration state in RAM.

- Unpatched: host permanently dead within one 4 minute run. Enumeration freezes and never recovers, only reboot helps.
- Patched: twice the exposure, host stayed alive and kept enumerating the whole time.

Happy to share the modified device_info example if useful.

This came out of a longer receive path investigation on the same board: hathach/tinyusb#3776.

<img width="640" height="495" alt="fj-debug" src="https://github.com/user-attachments/assets/96850884-1dff-452c-b799-3a323470fb56" />

