### PR TITLE
Recover packets received with a one bit framing offset

### DIFF
--- a/src/pio_usb.c
+++ b/src/pio_usb.c
@@ -245,6 +245,52 @@ int __no_inline_not_in_flash_func(pio_usb_bus_receive_packet_and_handshake)(
           pio_usb_bus_usb_transfer(pp, ack_encoded, 5);
           return idx - 4;
         }
+        // Deterministic SYNC realignment. The RX PIO can lock onto a packet a
+        // few bits early, so every byte is shifted and the aligned CRC fails on
+        // data that is actually valid (see sekigon-gonnoc/Pico-PIO-USB#97, open
+        // since 2023: 0x01 0xa5 captured for 0x80 0xd2). Because a correct
+        // packet always begins with SYNC (0x80), the amount of shift is not a
+        // guess: drop k leading bits until SYNC reappears, then confirm with the
+        // PID check nibble and a recomputed CRC. This keys on the SYNC marker
+        // (the standard USB SIE alignment technique, USB-IF SIE white paper) and
+        // recovers any small offset, unlike a blind single-bit retry.
+        if (idx >= 4 && idx <= 18) {
+          for (uint8_t k = 1; k <= 7; k++) {
+            uint8_t fixed[19];
+            for (int16_t i = 0; i < idx; i++) {
+              uint8_t hi = (i + 1 < idx) ? (uint8_t)(usb_rx_buffer[i + 1] << (8 - k)) : 0;
+              fixed[i] = (uint8_t)((usb_rx_buffer[i] >> k) | hi);
+            }
+            if (fixed[0] != USB_SYNC) {
+              continue;
+            }
+            uint8_t rpid = fixed[1];
+            if ((uint8_t)((rpid >> 4) ^ (rpid & 0x0f)) != 0x0f) {
+              continue;
+            }
+            // Try the realigned packet at its natural length and one byte
+            // shorter (the shift can drop the final partial byte).
+            for (int16_t n = idx; n >= idx - 1; n--) {
+              if (n < 4) {
+                continue;
+              }
+              uint16_t c = 0xffff;
+              for (int16_t i = 2; i < n - 2; i++) {
+                c = update_usb_crc16(c, fixed[i]);
+              }
+              c ^= 0xffff;
+              uint16_t rx_crc =
+                  (uint16_t)fixed[n - 2] | ((uint16_t)fixed[n - 1] << 8);
+              if (c == rx_crc) {
+                pio_usb_bus_usb_transfer(pp, ack_encoded, 5);
+                for (int16_t i = 0; i < n; i++) {
+                  usb_rx_buffer[i] = fixed[i];
+                }
+                return n - 4;
+              }
+            }
+          }
+        }
       } else if (handshake == USB_PID_NAK) {
         pio_usb_bus_usb_transfer(pp, nak_encoded, 5);
       } else {


### PR DESCRIPTION
The receiver can lock onto an incoming packet one bit late. Every byte then arrives shifted left by one with carry from the following byte, so the CRC check fails on wire data that is perfectly valid, the device retransmits forever, and the endpoint is stuck until reboot. Captured on an RP2350 host (Adafruit Fruit Jam, CH334F hub) where a hub status change report failed identically on every retry:

| byte | expected | received | check |
|---|---|---|---|
| sync | 80 | 01 | (80<<1)+idle carry |
| PID | 4b | 97 | (4b<<1)+1 |
| data | 02 | 04 | 02<<1 |
| crc lo | c1 | 82 | c1<<1 |
| crc hi | 7e | fd | (7e<<1)+1 |

When the aligned CRC check fails, undo the shift, require valid sync and PID check nibble, recompute the CRC, then ACK and deliver. Anything that fails these checks falls through unchanged.

Validated on the board above: 121 consecutive hub hot plug events delivered, about one realignment each, where previously the first event wedged the port until reboot. The late ACKs were accepted without issue.

Note #210 touches the same function, happy to rebase whichever merges second. Background: hathach/tinyusb#3776
